### PR TITLE
Add rust functions for set_thread_name in the Tracy C API

### DIFF
--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client-sys"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Simonas Kazlauskas <tracy-client-sys@kazlauskas.me>"]
 build = "build.rs"
 license = "MIT/Apache-2.0"

--- a/tracy-client-sys/src/lib.rs
+++ b/tracy-client-sys/src/lib.rs
@@ -165,6 +165,10 @@ enabled_fn! { pub fn ___tracy_emit_message_appinfo(
     size: usize
 ) }
 
+enabled_fn! { pub fn ___tracy_set_thread_name(
+    name: *const c_char,
+) }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Simonas Kazlauskas <tracy-client@kazlauskas.me>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -13,7 +13,7 @@ High level bindings to the client libraries for the Tracy profiler
 """
 
 [dependencies]
-tracy-client-sys = { version = "0.8.0", default-features = false }
+tracy-client-sys = { version = "0.8.1", default-features = false }
 
 [features]
 default = [ "enable" ]

--- a/tracy-client/examples/showcase.rs
+++ b/tracy-client/examples/showcase.rs
@@ -1,5 +1,5 @@
+use std::thread::{sleep, spawn};
 use tracy_client::*;
-use std::thread::{spawn, sleep};
 
 #[global_allocator]
 static GLOBAL: ProfiledAllocator<std::alloc::System> =
@@ -86,7 +86,6 @@ fn main() {
             finish_continuous_frame!("T5");
         }
     });
-
 
     message("starting t6", 10);
     let t6 = spawn(|| {

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -15,11 +15,16 @@
 //! [Tracy profiler]: https://github.com/wolfpld/tracy
 
 use std::alloc;
+use std::ffi::CString;
+
 #[doc(hidden)]
 pub use tracy_client_sys as sys;
 
 /// A handle representing a span of execution.
-pub struct Span(sys::TracyCZoneCtx, std::marker::PhantomData<*mut sys::TracyCZoneCtx>);
+pub struct Span(
+    sys::TracyCZoneCtx,
+    std::marker::PhantomData<*mut sys::TracyCZoneCtx>,
+);
 
 impl Span {
     /// Start a new Tracy span.
@@ -41,13 +46,19 @@ impl Span {
                 name.len(),
             );
             if callstack_depth == 0 {
-                Self(sys::___tracy_emit_zone_begin_alloc(loc, 1), std::marker::PhantomData)
+                Self(
+                    sys::___tracy_emit_zone_begin_alloc(loc, 1),
+                    std::marker::PhantomData,
+                )
             } else {
-                Self(sys::___tracy_emit_zone_begin_alloc_callstack(
-                    loc,
-                    adjust_stack_depth(callstack_depth).into(),
-                    1,
-                ), std::marker::PhantomData)
+                Self(
+                    sys::___tracy_emit_zone_begin_alloc_callstack(
+                        loc,
+                        adjust_stack_depth(callstack_depth).into(),
+                        1,
+                    ),
+                    std::marker::PhantomData,
+                )
             }
         }
     }
@@ -216,7 +227,7 @@ pub fn message(message: &str, callstack_depth: u16) {
         sys::___tracy_emit_message(
             message.as_ptr() as _,
             message.len(),
-            adjust_stack_depth(callstack_depth).into()
+            adjust_stack_depth(callstack_depth).into(),
         )
     }
 }
@@ -233,9 +244,15 @@ pub fn color_message(message: &str, rgba: u32, callstack_depth: u16) {
             message.as_ptr() as _,
             message.len(),
             rgba >> 8,
-            adjust_stack_depth(callstack_depth).into()
+            adjust_stack_depth(callstack_depth).into(),
         )
     }
+}
+
+pub fn set_thread_name(name: &str) {
+    let name = CString::new(name).unwrap();
+
+    unsafe { sys::___tracy_set_thread_name(name.as_ptr() as _) }
 }
 
 /// Create an instance of plot that can plot arbitrary `f64` values.


### PR DESCRIPTION
Tracy now has support for setting the thread name in the C API, this PR adds support for this!

I think you might have to publish the new versions to crates.io for everything to work, I'm not really sure how that works though.

I also ran `cargo fmt`, hence the formatting changes.