### PR TITLE
Add all named fields to the span name

### DIFF
--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -14,7 +14,7 @@ Inspect tracing-enabled Rust applications with Tracy
 
 [dependencies]
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.2", default-features = false, features = ["registry"] }
+tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "registry"] }
 tracy-client = { path = "../tracy-client", version = "0.9.0", default-features = false }
 
 [dev-dependencies]

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -212,6 +212,14 @@ mod tests {
     }
 
     #[test]
+    fn with_fields() {
+        setup_subscriber();
+        let span = span!(Level::TRACE, "a sec", name = "test");
+        let _enter = span.enter();
+        event!(Level::INFO, "EXPLOSION IN A SPAN WITH A NAME!");
+    }
+
+    #[test]
     fn multiple_entries() {
         setup_subscriber();
         let span = span!(Level::INFO, "multiple_entries");


### PR DESCRIPTION
This makes spans much more useful for me so I can see all the additional metadata in Tracy. Particularly having a span in bevy with a name of `"system"` and a field like `name = system.name()`, with this PR I can tell what systems are what in Tracy. I'm open to input for how to improve it.