### PR TITLE
Add span! macro

### DIFF
--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -19,6 +19,27 @@ use std::alloc;
 use std::ffi::CString;
 use tracy_client_sys as sys;
 
+/// Start a new Tracy span with function, file, and line determined automatically.
+#[macro_export]
+macro_rules! span {
+    ($name:expr, $callstack_depth:expr) => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let func_name = type_name_of(f);
+        let function = &func_name[..func_name.len() - 3];
+
+        tracy_client::Span::new(
+            $name,
+            function,
+            file!(),
+            line!(),
+            $callstack_depth,
+        )
+    }};
+}
+
 /// A handle representing a span of execution.
 #[cfg(feature="enable")]
 pub struct Span(


### PR DESCRIPTION
The macro uses `file!()` and `line!()` to determine the file name and line number to pass to `Span::new(...)`. It also uses a hack to determine the function name, which is the same hack used in [`stdext::function_name!`](https://docs.rs/stdext/0.3.1/src/stdext/macros.rs.html#63-74), since the [RFC](https://github.com/rust-lang/rfcs/issues/1743) to add a macro for this to the Rust stdlib is unresolved.

Alternatively, `stdext` could be added as a dependency, but that's probably overkill.

Also, it might be convenient to support omitting the `callstack_depth` with a default value of 62, which is the max according to Tracy documentation ("The maximum call stack depth that can be retrieved is 62 frames. This is a restriction at the level of operating system.").