### PR TITLE
Relax literal the requirement of the create_plot macro so that it can be used with stringify

### DIFF
--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -341,7 +341,7 @@ pub fn set_thread_name(name: &str) {
 /// ```
 #[macro_export]
 macro_rules! create_plot {
-    ($name: literal) => {
+    ($name: expr) => {
         unsafe { $crate::Plot::new_unchecked(concat!($name, "\0")) }
     };
 }


### PR DESCRIPTION
This matches what `concat!` uses https://doc.rust-lang.org/stable/core/macro.concat.html