### PR TITLE
Add `static_span!` macro that logs without allocating

### DIFF
--- a/.github/workflows/tracy-client.yml
+++ b/.github/workflows/tracy-client.yml
@@ -18,7 +18,11 @@ jobs:
       matrix:
         rust_toolchain: [nightly, stable, 1.40.0]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        flags: ["", "--release", "--no-default-features", "--all-features"]
+        flags: ["", "--release", "--no-default-features", "--features ci-all-features"]
+        include:
+          - rust_toolchain: nightly
+            os: ubuntu-latest
+            flags: "--features static_span"
     timeout-minutes: 20
     steps:
       - name: Checkout source

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -17,6 +17,9 @@ path = "../tracy-client-sys"
 version = ">=0.14.0, <0.17.0" # AUTO-UPDATE
 default-features = false
 
+[dependencies]
+const_format = { version = "0.2", features = ["fmt"], optional = true }
+
 [features]
 default = [ "enable" ]
 enable = [ "tracy-client-sys/enable" ]
@@ -24,3 +27,4 @@ delayed-init = [ "tracy-client-sys/delayed-init" ]
 lowres-timer = [ "tracy-client-sys/lowres-timer" ]
 noexit = [ "tracy-client-sys/noexit" ]
 ondemand = [ "tracy-client-sys/ondemand" ]
+static_span = [ "const_format" ]

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -28,3 +28,5 @@ lowres-timer = [ "tracy-client-sys/lowres-timer" ]
 noexit = [ "tracy-client-sys/noexit" ]
 ondemand = [ "tracy-client-sys/ondemand" ]
 static_span = [ "const_format" ]
+
+ci-all-features = [ "enable", "delayed-init", "lowres-timer", "noexit", "ondemand" ]

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -50,7 +50,14 @@ macro_rules! span {
     }};
 }
 
-#[cfg(feature="static_span")]
+#[cfg(all(feature="static_span", not(feature="enable")))]
+#[macro_export]
+macro_rules! static_span {
+    () => {{}};
+    ($name:expr) => {{}};
+}
+
+#[cfg(all(feature="static_span", feature="enable"))]
 #[macro_export]
 macro_rules! static_span {
     () => {{
@@ -169,16 +176,9 @@ impl Span {
     }
 
     #[doc(hidden)]
-    #[inline]
+    #[cfg(feature="enable")]
     pub fn private_new(ctx: sys::___tracy_c_zone_context) -> Self {
-        #[cfg(not(feature="enable"))]
-        {
-            return Self(());
-        }
-        #[cfg(feature="enable")]
-        {
-            Self(ctx, std::marker::PhantomData)
-        }
+        Self(ctx, std::marker::PhantomData)
     }
 
     /// Emit a numeric value associated with this span.


### PR DESCRIPTION
Sorry for the delay submitting this! This PR adds `static_span!`, gated behind a `static_span` feature gate since it depends on nightly features.

I verified that the crate works without nightly without the feature on
```
sujayakar@Sujays-MBP tracy-client % rustup override set stable
sujayakar@Sujays-MBP tracy-client % cargo test                       
```
and that the `const_format` dependency only shows up when the feature is on.
```
sujayakar@Sujays-MBP tracy-client % cargo tree                   
tracy-client v0.12.6 (/Users/sujayakar/src/rust_tracy_client/tracy-client)
└── tracy-client-sys v0.16.1 (/Users/sujayakar/src/rust_tracy_client/tracy-client-sys)
    [build-dependencies]
    └── cc v1.0.72
sujayakar@Sujays-MBP tracy-client % cargo tree --features static_span
tracy-client v0.12.6 (/Users/sujayakar/src/rust_tracy_client/tracy-client)
├── const_format v0.2.22
│   └── const_format_proc_macros v0.2.22 (proc-macro)
│       ├── proc-macro2 v1.0.32
│       │   └── unicode-xid v0.2.2
│       ├── quote v1.0.10
│       │   └── proc-macro2 v1.0.32 (*)
│       └── unicode-xid v0.2.2
└── tracy-client-sys v0.16.1 (/Users/sujayakar/src/rust_tracy_client/tracy-client-sys)
    [build-dependencies]
    └── cc v1.0.72
```

Closes #26.