### PR TITLE
Non-allocating `span!` macro

### DIFF
--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 High level bindings to the client libraries for the Tracy profiler
 """
 
+[dependencies]
+once_cell = "1.10"
+
 [dependencies.tracy-client-sys]
 path = "../tracy-client-sys"
 version = ">=0.14.0, <0.17.0" # AUTO-UPDATE


### PR DESCRIPTION
Alternative take on https://github.com/nagisa/rust_tracy_client/pull/28.

This introduces a new `once_cell` dependency; however, this is small, very widespread, and likely to move into std (https://github.com/rust-lang/rust/issues/74465).

Care was taken to ensure that the `Lazy` values are not dereferenced outside of the `#[cfg(feature = "enable")]` gate. Combined with inlining, this should allow invocations to be entirely erased when disabled, and very cheap when enabled.

Tests pass, but I haven't tried actually using this yet.