### PR TITLE
Define helper macros for trace output methods on Client

### DIFF
--- a/tracy-client/src/frame.rs
+++ b/tracy-client/src/frame.rs
@@ -108,3 +108,42 @@ impl Drop for Frame {
         }
     }
 }
+
+/// Convenience shortcut for [`Client::frame_mark`] on the current client.
+///
+/// # Panics
+///
+/// - If a `Client` isn't currently running.
+pub fn frame_mark() {
+    Client::running()
+        .expect("frame_mark! without a running Client")
+        .frame_mark();
+}
+
+/// Convenience macro for [`Client::secondary_frame_mark`] on the current client.
+///
+/// # Panics
+///
+/// - If a `Client` isn't currently running.
+#[macro_export]
+macro_rules! secondary_frame_mark {
+    ($name: literal) => {{
+        $crate::Client::running()
+            .expect("secondary_frame_mark! without a running Client")
+            .secondary_frame_mark($crate::frame_name!($name))
+    }};
+}
+
+/// Convenience macro for [`Client::non_continuous_frame`] on the current client.
+///
+/// # Panics
+///
+/// - If a `Client` isn't currently running.
+#[macro_export]
+macro_rules! non_continuous_frame {
+    ($name: literal) => {{
+        $crate::Client::running()
+            .expect("non_continuous_frame! without a running Client")
+            .non_continuous_frame($crate::frame_name!($name))
+    }};
+}

--- a/tracy-client/src/plot.rs
+++ b/tracy-client/src/plot.rs
@@ -37,3 +37,17 @@ macro_rules! plot_name {
         unsafe { $crate::internal::create_plot(concat!($name, "\0")) }
     };
 }
+
+/// Convenience macro for [`Client::plot`] on the current client.
+///
+/// # Panics
+///
+/// - If a `Client` isn't currently running.
+#[macro_export]
+macro_rules! plot {
+    ($name: literal, $value: expr) => {{
+        $crate::Client::running()
+            .expect("plot! without a running Client")
+            .plot($crate::plot_name!($name), $value)
+    }};
+}

--- a/tracy-client/tests/tests.rs
+++ b/tracy-client/tests/tests.rs
@@ -27,6 +27,7 @@ fn finish_frameset() {
     for _ in 0..10 {
         client.frame_mark();
     }
+    frame_mark();
 }
 
 fn finish_secondary_frameset() {
@@ -34,12 +35,14 @@ fn finish_secondary_frameset() {
     for _ in 0..5 {
         client.secondary_frame_mark(frame_name!("secondary frame"));
     }
+    secondary_frame_mark!("secondary frame macro");
 }
 
 fn non_continuous_frameset() {
     const NON_CONTINUOUS: FrameName = frame_name!("non continuous");
     let client = Client::start();
     client.non_continuous_frame(NON_CONTINUOUS);
+    non_continuous_frame!("non continuous macro");
 }
 
 fn plot_something() {
@@ -48,6 +51,8 @@ fn plot_something() {
     for i in 0..10 {
         client.plot(TEMPERATURE, i as f64);
     }
+
+    plot!("temperature", 42.0);
 }
 
 fn allocations() {
@@ -84,6 +89,11 @@ fn tls_confusion() {
     let _ = Client::start();
 }
 
+fn set_thread_name() {
+    let _client = Client::start();
+    set_thread_name!("test thread");
+}
+
 fn main() {
     #[cfg(not(loom))]
     {
@@ -100,5 +110,6 @@ fn main() {
             let _client = Client::start();
             fib(25);
         });
+        set_thread_name();
     }
 }


### PR DESCRIPTION
Not yet tested with Tracy, but these are pretty simple.

Discussion points:
- IMO these would be more convenient if they no-op'd rather than panicing when enabled at compiletime but disabled at runtime. In particular, this would make it more useful to use tracy-enabled binaries routinely, whereas IIRC enabled-but-unused tracy code is very leaky due to buffering? However, this would require adding state and branching to the `Span` and `Frame` objects.
- `frame_mark` doesn't have to be a macro, so it isn't. This might be surprising, since every other convenience interface is a macro. OTOH, most code bases will probably call this in exactly one place, so maybe no big deal?