### PR TITLE
Set Tracy thread names according to Rust std thread names

### DIFF
--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -47,7 +47,12 @@
 //! Refer to the [`client::sys`] crate for documentation on crate features. This crate re-exports
 //! all the features from [`client`].
 
-use std::{borrow::Cow, cell::RefCell, collections::VecDeque, fmt::Write};
+use std::{
+    borrow::Cow,
+    cell::{Cell, RefCell},
+    collections::VecDeque,
+    fmt::Write,
+};
 use tracing_core::{
     field::{Field, Visit},
     span::{Attributes, Id, Record},
@@ -68,6 +73,9 @@ thread_local! {
     /// A stack of spans currently active on the current thread.
     static TRACY_SPAN_STACK: RefCell<VecDeque<(Span, u64)>> =
         RefCell::new(VecDeque::with_capacity(16));
+
+    /// Indicator of whether `Client::set_thread_name_from_std` has been called for this thread.
+    static TRACY_THREAD_NAME_INIT: Cell<bool> = Cell::new(false);
 }
 
 /// A tracing layer that collects data in Tracy profiling format.
@@ -128,6 +136,15 @@ impl<F> TracyLayer<F> {
         } else {
             data
         }
+    }
+
+    fn set_tracy_thread_name_once(&self) {
+        TRACY_THREAD_NAME_INIT.with(|is_init| {
+            if !is_init.get() {
+                is_init.set(true);
+                self.client.set_thread_name_from_std();
+            }
+        });
     }
 }
 
@@ -200,6 +217,7 @@ where
                     id.into_u64(),
                 ));
             });
+            self.set_tracy_thread_name_once();
         }
     }
 
@@ -223,6 +241,7 @@ where
                 );
             }
         });
+        self.set_tracy_thread_name_once();
     }
 
     fn on_event(&self, event: &Event, _: Context<'_, S>) {
@@ -246,6 +265,7 @@ where
         if visitor.frame_mark {
             self.client.frame_mark();
         }
+        self.set_tracy_thread_name_once();
     }
 }
 

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -148,6 +148,23 @@ impl Client {
             internal::set_thread_name(name.as_ptr().cast());
         }
     }
+
+    /// Set the current thread name according to Rust's [`Thread::name()`].
+    ///
+    /// This is useful if the thread name is already set with Rust's standard library APIs, and you
+    /// want to copy the name to Tracy. Does nothing if the current thread is not named according
+    /// to [`Thread::name()`].
+    ///
+    /// [`Thread::name()`]: std::thread::Thread::name
+    pub fn set_thread_name_from_std(&self) {
+        #[cfg(feature = "enable")]
+        {
+            if let Some(name) = std::thread::current().name() {
+                // This will not panic because Rust disallows thread names with null bytes.
+                self.set_thread_name(name);
+            }
+        }
+    }
 }
 
 /// Convenience macro for [`Client::set_thread_name`] on the current client.

--- a/tracy-client/tests/tests.rs
+++ b/tracy-client/tests/tests.rs
@@ -92,6 +92,21 @@ fn tls_confusion() {
 fn set_thread_name() {
     let _client = Client::start();
     set_thread_name!("test thread");
+    // Test with unnamed threads.
+    let t1 = std::thread::spawn(|| {
+        let client = Client::start();
+        client.set_thread_name_from_std();
+    });
+    let _ = t1.join();
+    // Test with named threads.
+    let t2 = std::thread::Builder::new()
+        .name("thread name".to_owned())
+        .spawn(|| {
+            let client = Client::start();
+            client.set_thread_name_from_std();
+        })
+        .unwrap();
+    let _ = t2.join();
 }
 
 fn main() {


### PR DESCRIPTION
Rust's std library has the concept of [named threads](https://doc.rust-lang.org/std/thread/#naming-threads), but the names are currently not passed to Tracy.

This PR adds `set_thread_name_from_std()` in tracy-client for passing the std thread names to Tracy, and does so automatically in tracing-tracy when the first span or event is handled for each thread.