### PR TITLE
Set default callstack_depth to 0

### DIFF
--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -85,7 +85,7 @@ impl TracyLayer<DefaultFields> {
     pub fn new() -> Self {
         Self {
             fmt: DefaultFields::default(),
-            stack_depth: 64,
+            stack_depth: 0,
             client: Client::start(),
         }
     }
@@ -94,7 +94,9 @@ impl TracyLayer<DefaultFields> {
 impl<F> TracyLayer<F> {
     /// Specify the maximum number of stack frames that will be collected.
     ///
-    /// Specifying 0 frames will disable stack trace collection.
+    /// Note that enabling callstack collection can and will introduce a non-trivial overhead at
+    /// every instrumentation point. Specifying 0 frames (which is the default) will disable stack
+    /// trace collection.
     pub fn with_stackdepth(mut self, stack_depth: u16) -> Self {
         self.stack_depth = stack_depth;
         self
@@ -123,7 +125,8 @@ impl<F> TracyLayer<F> {
             while !data.is_char_boundary(max_len) {
                 max_len -= 1;
             }
-            self.client.color_message(error_msg, 0xFF000000, self.stack_depth);
+            self.client
+                .color_message(error_msg, 0xFF000000, self.stack_depth);
             &data[..max_len]
         } else {
             data

--- a/tracy-client/benches/client.rs
+++ b/tracy-client/benches/client.rs
@@ -18,25 +18,25 @@ fn client_running(c: &mut Criterion) {
 }
 
 fn ops_alloc(c: &mut Criterion) {
-    let _client = tracy_client::Client::start();
+    let client = tracy_client::Client::start();
     c.bench_function("span_alloc_callstack/0", |bencher| {
         bencher.iter(|| {
-            Client::running()
-                .unwrap()
+            client
+                .clone()
                 .span_alloc("hello", "function", "file", 42, 0);
         });
     });
     c.bench_function("span_alloc_callstack/100", |bencher| {
         bencher.iter(|| {
-            Client::running()
-                .unwrap()
+            client
+                .clone()
                 .span_alloc("hello", "function", "file", 42, 100);
         });
     });
 }
 
 fn ops_static(c: &mut Criterion) {
-    let client = tracy_client::Client::start();
+    let _client = tracy_client::Client::start();
     c.bench_function("span_callstack/0", |bencher| {
         bencher.iter(|| {
             tracy_client::span!("some_name", 0);

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -110,7 +110,9 @@ pub struct Client(());
 impl Client {
     /// Output a message.
     ///
-    /// `callstack_depth` specifies the maximum number of stack frames client should collect.
+    /// Specifying a non-zero `callstack_depth` will enable collection of callstack for this
+    /// message. The number provided will limit the number of call frames collected. Note that
+    /// enabling callstack collection introduces a non-trivial amount of overhead to this call.
     pub fn message(&self, message: &str, callstack_depth: u16) {
         #[cfg(feature = "enable")]
         unsafe {
@@ -121,7 +123,9 @@ impl Client {
 
     /// Output a message with an associated color.
     ///
-    /// `callstack_depth` specifies the maximum number of stack frames client should collect.
+    /// Specifying a non-zero `callstack_depth` will enable collection of callstack for this
+    /// message. The number provided will limit the number of call frames collected. Note that
+    /// enabling callstack collection introduces a non-trivial amount of overhead to this call.
     ///
     /// The colour shall be provided as RGBA, where the least significant 8 bits represent the alpha
     /// component and most significant 8 bits represent the red component.
@@ -189,6 +193,11 @@ pub struct ProfiledAllocator<T>(T, u16);
 
 impl<T> ProfiledAllocator<T> {
     /// Construct a new `ProfiledAllocator`.
+    ///
+    /// Specifying a non-zero `callstack_depth` will enable collection of callstack for this
+    /// message. The number provided will limit the number of call frames collected. Note that
+    /// enabling callstack collection introduces a non-trivial amount of overhead to each
+    /// allocation and deallocation.
     pub const fn new(inner_allocator: T, callstack_depth: u16) -> Self {
         Self(inner_allocator, adjust_stack_depth(callstack_depth))
     }

--- a/tracy-client/src/span.rs
+++ b/tracy-client/src/span.rs
@@ -37,8 +37,10 @@ impl Client {
     /// In order to obtain a [`SpanLocation`] value to provide to this function use the
     /// [`span_location!`](crate::span_location) macro.
     ///
-    /// `callstack_depth` specifies the maximum number of stack frames the client should collect.
-    /// On some systems this value may be clamped to a maximum value supported by the target.
+    /// Specifying a non-zero `callstack_depth` will enable collection of callstack for this
+    /// message. The number provided will limit the number of call frames collected. Note that
+    /// enabling callstack collection introduces a non-trivial amount of overhead to this call. On
+    /// some systems this value may be clamped to a maximum value supported by the target.
     ///
     /// The [`span!`](crate::span!) macro is a convenience wrapper over this method.
     ///
@@ -83,8 +85,10 @@ impl Client {
     /// profiler. Prefer the [`Client::span`] as a allocation-free and faster alternative when
     /// possible.
     ///
-    /// `callstack_depth` specifies the maximum number of stack frames client should collect. On
-    /// some systems this value may be clamped to a maximum value supported on the target.
+    /// Specifying a non-zero `callstack_depth` will enable collection of callstack for this
+    /// message. The number provided will limit the number of call frames collected. Note that
+    /// enabling callstack collection introduces a non-trivial amount of overhead to this call. On
+    /// some systems this value may be clamped to a maximum value supported by the target.
     ///
     /// # Example
     ///
@@ -227,17 +231,21 @@ macro_rules! span_location {
 /// let _span = span!("some span");
 /// ```
 ///
-/// It is also possible to specify the number of frames to capture in the callstack:
+/// It is also possible to enable collection of the callstack by specifying a limit of call stack
+/// frames to record:
 ///
 /// ```
 /// use tracy_client::span;
 /// # let _client = tracy_client::Client::start();
 /// let _span = span!("some span", 32);
 /// ```
+///
+/// Note, however, that collecting callstack introduces a non-trivial overhead at the point of
+/// instrumentation.
 #[macro_export]
 macro_rules! span {
     ($name: expr) => {
-        $crate::span!($name, 62)
+        $crate::span!($name, 0)
     };
     ($name: expr, $callstack_depth: expr) => {{
         let location = $crate::span_location!($name);


### PR DESCRIPTION
Collecting callstacks is quite expensive and can make each
instrumentation point ~100 times slower (200ns -> 20µs). Originally
callstack collection was enabled by default in a hope to provide a great
out-of-the-box experience by just enabling the layer or inserting some
instrumentation points. In retrospective that is a poor default.

Compared to figuring out why the performance is suffering, it seems like
it would be _much_ easier for user to discover how to enable collection
of stack frames when they find themselves wanting to see some in their
profiles. It also gives us an opportunity to visibly document the
pitfalls of enabling collection of the stack frames.