### PR TITLE
Cache buffers, allow omitting span names, options for not formatting KVs all the time

### DIFF
--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -20,6 +20,7 @@ bench = true
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "registry"] }
 client = { package = "tracy-client", path = "../tracy-client", version = "0.14.0", default-features = false }
+crossbeam-queue = "0.3.5"
 
 [dev-dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/tracing-tracy/src/buffers.rs
+++ b/tracing-tracy/src/buffers.rs
@@ -1,0 +1,110 @@
+//! Caches for buffers into which information is formatted.
+
+use crossbeam_queue::ArrayQueue;
+use std::cell::RefCell;
+use std::mem::ManuallyDrop;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use tracing_subscriber::fmt::FormattedFields;
+
+const DEFAULT_BUFFER_SIZE: usize = 64;
+
+/// Provide a reference to a buffer for use-cases where it does not need to live outside of a
+/// closure (such as would be the case for events).
+pub(crate) fn with_event_buffer<F, C: FnOnce(&mut FormattedFields<F>)>(closure: C) {
+    thread_local! {
+        static BUFFER: std::cell::RefCell<Option<String>>  =
+            RefCell::new(Some(String::with_capacity(DEFAULT_BUFFER_SIZE)));
+    }
+    BUFFER.with(|buffer| {
+        let mut none = None;
+        let mut storage = buffer.try_borrow_mut();
+        let (buffer, storage) = match storage.as_mut().map(|b| (b.take(), b)) {
+            Ok((Some(buffer), storage)) => (buffer, &mut **storage),
+            _ => (String::with_capacity(DEFAULT_BUFFER_SIZE), &mut none),
+        };
+        let mut ff = FormattedFields::<F>::new(buffer);
+        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| closure(&mut ff)));
+        if let Some(storage) = storage {
+            ff.fields.clear();
+            *storage = ff.fields;
+        }
+        if let Err(panic) = panic {
+            std::panic::resume_unwind(panic);
+        }
+    });
+}
+
+#[derive(Clone)]
+pub(crate) struct BufferPool<F> {
+    pub(crate) pool: Arc<ArrayQueue<FormattedFields<F>>>,
+    pub(crate) buffer_size: usize,
+}
+
+impl<F> BufferPool<F> {
+    pub(crate) fn new(num_buffers: usize, buffer_size: usize) -> Self {
+        let pool = Arc::new(ArrayQueue::new(num_buffers));
+        for _ in 0..num_buffers {
+            let _ = pool.push(FormattedFields::new(String::with_capacity(buffer_size)));
+        }
+        Self { pool, buffer_size }
+    }
+
+    pub(crate) fn remake<F2>(self, num_buffers: usize, buffer_size: usize) -> BufferPool<F2> {
+        let pool = Arc::new(ArrayQueue::new(num_buffers));
+        for _ in 0..num_buffers {
+            let buffer = self.pool.pop().map(|v| FormattedFields::new(v.fields));
+            let buffer =
+                buffer.unwrap_or_else(|| FormattedFields::new(String::with_capacity(buffer_size)));
+            let _ = pool.push(buffer);
+        }
+        BufferPool { pool, buffer_size }
+    }
+
+    pub(crate) fn get(&self) -> ReturnableBuffer<F> {
+        let buffer = self.pool.pop();
+        let buffer = buffer.map(|b| ReturnableBuffer {
+            buffer: ManuallyDrop::new(b),
+            pool: Some(Arc::clone(&self.pool)),
+        });
+        buffer.unwrap_or_else(|| ReturnableBuffer {
+            buffer: ManuallyDrop::new(FormattedFields::new(String::with_capacity(
+                DEFAULT_BUFFER_SIZE,
+            ))),
+            pool: None,
+        })
+    }
+}
+
+pub(crate) struct ReturnableBuffer<F> {
+    buffer: ManuallyDrop<FormattedFields<F>>,
+    // This is hella expensive :(
+    pool: Option<Arc<ArrayQueue<FormattedFields<F>>>>,
+}
+
+impl<F> Drop for ReturnableBuffer<F> {
+    fn drop(&mut self) {
+        let mut buffer = unsafe {
+            // SAFE: we ensure that `Drop` is the only place where this method is called on this
+            // field, and `drop` is only ever called once by definition.
+            ManuallyDrop::take(&mut self.buffer)
+        };
+        if let Some(pool) = &mut self.pool {
+            buffer.fields.clear();
+            let _ = pool.push(buffer);
+        }
+    }
+}
+
+impl<F> std::ops::Deref for ReturnableBuffer<F> {
+    type Target = FormattedFields<F>;
+    fn deref(&self) -> &Self::Target {
+        &*self.buffer
+    }
+}
+
+impl<F> std::ops::DerefMut for ReturnableBuffer<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.buffer
+    }
+}

--- a/tracing-tracy/src/fmt.rs
+++ b/tracing-tracy/src/fmt.rs
@@ -1,0 +1,93 @@
+use tracing_core::field::Visit;
+use tracing_core::Field;
+use tracing_subscriber::field::{MakeVisitor, RecordFields, VisitFmt, VisitOutput};
+
+/// Handle fields with the `tracy.` prefix specially.
+///
+/// * `tracy.frame_mark` event will cause a frame mark to be emitted;
+/// * All other fields with the `tracy.` prefix are reserved and will be omitted.
+pub struct TracyFields<F>(client::Client, F);
+
+impl<F> TracyFields<F> {
+    pub fn new(client: client::Client, inner: F) -> Self {
+        Self(client, inner)
+    }
+}
+
+impl<F, W> MakeVisitor<W> for TracyFields<F>
+where
+    F: MakeVisitor<W>,
+{
+    type Visitor = TracyFieldsVisitor<F::Visitor>;
+    fn make_visitor(&self, target: W) -> Self::Visitor {
+        TracyFieldsVisitor {
+            client: self.0.clone(),
+            inner_visitor: self.1.make_visitor(target),
+            frame_mark: false,
+        }
+    }
+}
+
+pub struct TracyFieldsVisitor<V> {
+    inner_visitor: V,
+    client: client::Client,
+    frame_mark: bool,
+}
+
+impl<V> TracyFieldsVisitor<V> {
+    fn visit_field<Val, Cb: FnOnce(&mut V)>(&mut self, field: &Field, _: Val, otherwise: Cb) {
+        if field.name().starts_with("tracy.") {
+        } else {
+            otherwise(&mut self.inner_visitor)
+        }
+    }
+}
+
+impl<V> Visit for TracyFieldsVisitor<V>
+where
+    V: Visit,
+{
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.visit_field(field, value, |v| v.record_debug(field, value))
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.visit_field(field, value, |v| v.record_f64(field, value))
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.visit_field(field, value, |v| v.record_i64(field, value))
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.visit_field(field, value, |v| v.record_u64(field, value))
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if value && field.name() == "tracy.frame_mark" {
+            self.frame_mark = true;
+        }
+        self.visit_field(field, value, |v| v.record_bool(field, value))
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.visit_field(field, value, |v| v.record_str(field, value))
+    }
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.visit_field(field, value, |v| v.record_error(field, value))
+    }
+}
+
+impl<V: VisitFmt> VisitFmt for TracyFieldsVisitor<V> {
+    fn writer(&mut self) -> &mut dyn core::fmt::Write {
+        self.inner_visitor.writer()
+    }
+}
+
+impl<R, V: VisitOutput<R>> VisitOutput<R> for TracyFieldsVisitor<V> {
+    fn finish(self) -> R {
+        if self.frame_mark {
+            self.client.frame_mark();
+        }
+        self.inner_visitor.finish()
+    }
+
+    fn visit<F: RecordFields>(self, fields: &F) -> R {
+        self.inner_visitor.visit(fields)
+    }
+}

--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -100,56 +100,102 @@ fn span_with_fields() {
 }
 
 fn benchmark_span(c: &mut Criterion) {
-    c.bench_function("span/callstack", |bencher| {
+    c.bench_function("span/callstack+keys_and_values", |bencher| {
         let layer =
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                let _span = tracing::error_span!("message").entered();
+                let _span = tracing::error_span!("span/callstack+keys_and_values", foo=42).entered();
             });
         })
     });
 
-    c.bench_function("span/no_callstack", |bencher| {
+    c.bench_function("span/keys_and_values", |bencher| {
         let layer =
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                let _span = tracing::error_span!("message").entered();
+                let _span = tracing::error_span!("span/keys_and_values", foo=42).entered();
+            });
+        })
+    });
+
+    c.bench_function("span", |bencher| {
+        let layer = tracing_subscriber::registry().with(
+            super::TracyLayer::new()
+                .with_stackdepth(0)
+                .with_keys_and_values(false),
+        );
+        tracing::subscriber::with_default(layer, || {
+            bencher.iter(|| {
+                let _span = tracing::error_span!("span", foo=42).entered();
             });
         })
     });
 }
 
 fn benchmark_message(c: &mut Criterion) {
-    c.bench_function("event/callstack", |bencher| {
+    c.bench_function("event/callstack+keys_and_values", |bencher| {
         let layer =
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                tracing::error!("message");
+                tracing::error!("event/callstack+keys_and_values");
             });
         })
     });
 
-    c.bench_function("event/no_callstack", |bencher| {
+    c.bench_function("event/keys_and_values", |bencher| {
         let layer =
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                tracing::error!("message");
+                tracing::error!("event/keys_and_values");
             });
         })
     });
 
-    c.bench_function("event_kvs/no_callstack", |bencher| {
+    c.bench_function("event", |bencher| {
+        let layer = tracing_subscriber::registry().with(
+            super::TracyLayer::new()
+                .with_stackdepth(0)
+                .with_keys_and_values(false),
+        );
+        tracing::subscriber::with_default(layer, || {
+            bencher.iter(|| {
+                tracing::error!("event");
+            });
+        })
+    });
+
+    c.bench_function("event_with_kv/keys_and_values", |bencher| {
         let layer =
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let error = None::<()>;
                 tracing::error!(
-                    message = "message",
+                    message = "event_with_kv/keys_and_values",
+                    number = 42u32,
+                    boolean = true,
+                    string = "benchmark",
+                    ?error
+                );
+            });
+        })
+    });
+
+    c.bench_function("event_with_kv", |bencher| {
+        let layer = tracing_subscriber::registry().with(
+            super::TracyLayer::new()
+                .with_stackdepth(0)
+                .with_keys_and_values(false),
+        );
+        tracing::subscriber::with_default(layer, || {
+            bencher.iter(|| {
+                let error = None::<()>;
+                tracing::error!(
+                    message = "event_with_kv",
                     number = 42u32,
                     boolean = true,
                     string = "benchmark",
@@ -185,5 +231,6 @@ pub(crate) fn main() {
             .build()
             .expect("tokio runtime");
         runtime.block_on(async_futures());
+        std::thread::sleep(std::time::Duration::from_secs(3))
     }
 }

--- a/tracy-client/benches/client.rs
+++ b/tracy-client/benches/client.rs
@@ -23,14 +23,14 @@ fn ops_alloc(c: &mut Criterion) {
         bencher.iter(|| {
             client
                 .clone()
-                .span_alloc("hello", "function", "file", 42, 0);
+                .span_alloc(Some("hello"), "function", "file", 42, 0);
         });
     });
     c.bench_function("span_alloc_callstack/100", |bencher| {
         bencher.iter(|| {
             client
                 .clone()
-                .span_alloc("hello", "function", "file", 42, 100);
+                .span_alloc(Some("hello"), "function", "file", 42, 100);
         });
     });
 }

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -39,6 +39,7 @@ pub mod internal {
     pub use crate::{span::SpanLocation, sys};
     pub use once_cell::sync::Lazy;
     pub use std::any::type_name;
+    pub use std::ptr::null;
     use std::ffi::CString;
 
     #[inline(always)]

--- a/tracy-client/tests/tests.rs
+++ b/tracy-client/tests/tests.rs
@@ -116,7 +116,7 @@ fn main() {
         nameless_span();
         let thread = std::thread::spawn(|| {
             let _client = Client::start();
-            fib(25);
+            fib(20);
         });
         thread.join().unwrap();
         set_thread_name();


### PR DESCRIPTION
With this plain `error!("banana")` can take as little as 200ns (~0 overhead) but it will also lead to no meaningful messages if you have `error!(someotherkey)`, and it will also drop all the KVs too.

Similarly, emitting a span can happen in “just” 1.2µs which is also pretty nice.

Finally, `tracy_client::span!()` “just works” and produces meaningful trace outputs, which is _very_ nice. I think this one is likely uncontroversial and can be landed as is (see 2nd commit).

Otherwise this is just a code/brain dump to which I don't anticipate returning for a foreseeable future. If somebody/anybody wants to finish this up somehow, I encourage you to do so ^^.