### PR TITLE
Support linking against prebuilt tracy client

### DIFF
--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -50,7 +50,7 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
 fn main() {
     if let Ok(lib) = std::env::var("TRACY_CLIENT_LIB") {
         if let Ok(lib_path) = std::env::var("TRACY_CLIENT_LIB_PATH") {
-            println!("cargo:rustc-link-search={}", lib_path);
+            println!("cargo:rustc-link-search=native={}", lib_path);
         }
         println!("cargo:rustc-link-lib={}", lib);
     } else {


### PR DESCRIPTION
I'm using this crate in a scenario with both rust and C++ code using the same tracy client, I'd like to be able to manually specify the tracy client to link against instead of having it hard-coded inside this crate, which would cause duplicate defined symbols.

Here I propose to add the following environment variables:
- TRACY_CLIENT_LIB: when set, links against this tracy client library instead of building it
- TRACY_CLIENT_LIB_PATH: when TRACY_CLIENT_LIB is set, this may contain additional library search paths

The approach is similar to https://crates.io/crates/openssl-sys , which also has a set of environment variables that control how the C/C++ code is linked/compiled