### PR TITLE
Bump package versions

### DIFF
--- a/make_sys.sh
+++ b/make_sys.sh
@@ -83,7 +83,7 @@ sed -i "s/^\(version =\) \".*\" \(# AUTO-BUMP\)$/\1 \"$NEXT_SYS_VERSION\" \2/" \
 # …and the versions in tracy-client.
 sed -i "s/^\(version =\) \".*\" \(# AUTO-BUMP\)$/\1 \"$NEXT_CLIENT_VERSION\" \2/" \
     tracy-client/Cargo.toml
-sed -i "s/^\(version =\) \".*\" \(# AUTO-UPDATE\)$/\1 \">=0.17.0, <$NEXTNEXT_SYS_VERSION\" \2/" \
+sed -i "s/^\(version =\) \".*\" \(# AUTO-UPDATE\)$/\1 \">=0.21.2, <$NEXTNEXT_SYS_VERSION\" \2/" \
     tracy-client/Cargo.toml
 
 # Make a commit that we'll PR

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-tracy"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Simonas Kazlauskas <tracing-tracy@kazlauskas.me>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -19,7 +19,7 @@ bench = true
 [dependencies]
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "registry"] }
-client = { package = "tracy-client", path = "../tracy-client", version = "0.16.0", default-features = false }
+client = { package = "tracy-client", path = "../tracy-client", version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client-sys"
-version = "0.21.1" # AUTO-BUMP
+version = "0.21.2" # AUTO-BUMP
 authors = ["Simonas Kazlauskas <tracy-client-sys@kazlauskas.me>"]
 build = "build.rs"
 license = "(MIT OR Apache-2.0) AND BSD-3-Clause"

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client"
-version = "0.16.1" # AUTO-BUMP
+version = "0.16.2" # AUTO-BUMP
 authors = ["Simonas Kazlauskas <tracy-client@kazlauskas.me>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -36,7 +36,7 @@ once_cell = "1.10"
 [dependencies.sys]
 path = "../tracy-client-sys"
 package = "tracy-client-sys"
-version = ">=0.17.0, <0.22.0" # AUTO-UPDATE
+version = ">=0.21.2, <0.22.0" # AUTO-UPDATE
 default-features = false
 features = ["manual-lifetime", "delayed-init"]
 


### PR DESCRIPTION
Includes #66 

Seems unfortunate that all of the packages needed a bump, but it also makes sense – how can an upstream package control a feature of a downstream package if said package does not have the feature :)?