### PR TITLE
Don't gate code based on enable flag

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -16,7 +16,7 @@ expose the data it collects in the background to that same network. Traces colle
 may include source and assembly code as well.
 
 As thus, you may want make sure to only enable the `tracing-tracy`, `tracy-client` and
-`tracy-client-sys` crates conditionally, via the `enable` feature flag provided by the crates.
+`tracy-client-sys` crates conditionally, via a tracing feature in your crate.
 
 ## Version support table
 

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -31,12 +31,11 @@ criterion = "0.3"
 
 [features]
 # Refer to FEATURES.mkd for documentation on features.
-default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
+default = [ "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
             "broadcast", "callstack-inlines" ]
 broadcast = ["client/broadcast"]
 code-transfer = ["client/code-transfer"]
 context-switch-tracing = ["client/context-switch-tracing"]
-enable = ["client/enable"]
 fibers = ["client/fibers"]
 timer-fallback = ["client/timer-fallback"]
 ondemand = ["client/ondemand"]

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -37,8 +37,8 @@
 //! expose the data it collects in the background to that same network. Traces collected by Tracy
 //! may include source and assembly code as well.
 //!
-//! As thus, you may want make sure to only enable the `tracing-tracy` crate conditionally, via the
-//! `enable` feature flag provided by this crate.
+//! As thus, you may want make sure to only enable the `tracing-tracy` crate conditionally, via a
+//! tracing feature in your crate.
 //!
 //! [Tracy]: https://github.com/wolfpld/tracy
 //!

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -26,8 +26,6 @@ cc = { version = "1.0.82", default-features = false }
 
 [features]
 # Refer to FEATURES.mkd for documentation on features.
-default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
 enable = []
 fibers = []
 system-tracing = []

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -38,19 +38,18 @@ path = "../tracy-client-sys"
 package = "tracy-client-sys"
 version = ">=0.21.2, <0.23.0" # AUTO-UPDATE
 default-features = false
-features = ["manual-lifetime", "delayed-init"]
+features = ["enable", "manual-lifetime", "delayed-init"]
 
 [target.'cfg(loom)'.dependencies.loom]
 version = "0.5"
 
 [features]
 # Refer to FEATURES.mkd for documentation on features.
-default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
+default = [ "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
             "broadcast", "callstack-inlines" ]
 broadcast = ["sys/broadcast"]
 code-transfer = ["sys/code-transfer"]
 context-switch-tracing = ["sys/context-switch-tracing"]
-enable = ["sys/enable"]
 fibers = ["sys/fibers"]
 timer-fallback = ["sys/timer-fallback"]
 ondemand = ["sys/ondemand"]

--- a/tracy-client/src/plot.rs
+++ b/tracy-client/src/plot.rs
@@ -16,20 +16,12 @@ impl PlotName {
     /// The resulting value may be used as an argument for the the [`Client::secondary_frame_mark`]
     /// and [`Client::non_continuous_frame`] methods.
     pub fn new_leak(name: String) -> Self {
-        #[cfg(feature = "enable")]
-        {
-            // Ensure the name is null-terminated.
-            let mut name = name;
-            name.push('\0');
-            // Drop excess capacity by converting into a boxed str, then leak.
-            let name = Box::leak(name.into_boxed_str());
-            Self(name)
-        }
-        #[cfg(not(feature = "enable"))]
-        {
-            drop(name);
-            Self("\0")
-        }
+        // Ensure the name is null-terminated.
+        let mut name = name;
+        name.push('\0');
+        // Drop excess capacity by converting into a boxed str, then leak.
+        let name = Box::leak(name.into_boxed_str());
+        Self(name)
     }
 }
 
@@ -46,7 +38,6 @@ impl Client {
     ///     .plot(tracy_client::plot_name!("temperature"), 37.0);
     /// ```
     pub fn plot(&self, plot_name: PlotName, value: f64) {
-        #[cfg(feature = "enable")]
         unsafe {
             // SAFE: We made sure the `plot` refers to a null-terminated string.
             sys::___tracy_emit_plot(plot_name.0.as_ptr().cast(), value);

--- a/tracy-client/src/span.rs
+++ b/tracy-client/src/span.rs
@@ -5,26 +5,17 @@ use std::ffi::CString;
 ///
 /// The trace span will be ended when this type is dropped.
 pub struct Span {
-    #[cfg(feature = "enable")]
     client: Client,
-    #[cfg(feature = "enable")]
     zone: sys::___tracy_c_zone_context,
-    #[cfg(feature = "enable")]
     _no_send_sync: std::marker::PhantomData<*mut sys::___tracy_c_zone_context>,
-    #[cfg(not(feature = "enable"))]
-    _no_send_sync: std::marker::PhantomData<*mut ()>,
 }
 
 /// A statically allocated location information for a span.
 ///
 /// Construct with the [`span_location!`](crate::span_location) macro.
 pub struct SpanLocation {
-    #[cfg(feature = "enable")]
     pub(crate) _function_name: CString,
-    #[cfg(feature = "enable")]
     pub(crate) data: sys::___tracy_source_location_data,
-    #[cfg(not(feature = "enable"))]
-    pub(crate) _internal: (),
 }
 
 unsafe impl Send for SpanLocation {}
@@ -59,7 +50,6 @@ impl Client {
     /// ```
     #[inline]
     pub fn span(self, loc: &'static SpanLocation, callstack_depth: u16) -> Span {
-        #[cfg(feature = "enable")]
         unsafe {
             let zone = if callstack_depth == 0 {
                 sys::___tracy_emit_zone_begin(&loc.data, 1)
@@ -72,10 +62,6 @@ impl Client {
                 zone,
                 _no_send_sync: std::marker::PhantomData,
             }
-        }
-        #[cfg(not(feature = "enable"))]
-        Span {
-            _no_send_sync: std::marker::PhantomData,
         }
     }
 
@@ -112,7 +98,6 @@ impl Client {
         line: u32,
         callstack_depth: u16,
     ) -> Span {
-        #[cfg(feature = "enable")]
         unsafe {
             let loc = sys::___tracy_alloc_srcloc_name(
                 line,
@@ -135,17 +120,12 @@ impl Client {
                 _no_send_sync: std::marker::PhantomData,
             }
         }
-        #[cfg(not(feature = "enable"))]
-        Span {
-            _no_send_sync: std::marker::PhantomData,
-        }
     }
 }
 
 impl Span {
     /// Emit a numeric value associated with this span.
     pub fn emit_value(&self, value: u64) {
-        #[cfg(feature = "enable")]
         unsafe {
             // SAFE: the only way to construct `Span` is by creating a valid tracy zone context.
             sys::___tracy_emit_zone_value(self.zone, value);
@@ -154,7 +134,6 @@ impl Span {
 
     /// Emit some text associated with this span.
     pub fn emit_text(&self, text: &str) {
-        #[cfg(feature = "enable")]
         unsafe {
             // SAFE: the only way to construct `Span` is by creating a valid tracy zone context.
             sys::___tracy_emit_zone_text(self.zone, text.as_ptr().cast(), text.len());
@@ -163,7 +142,6 @@ impl Span {
 
     /// Emit a color associated with this span.
     pub fn emit_color(&self, color: u32) {
-        #[cfg(feature = "enable")]
         unsafe {
             // SAFE: the only way to construct `Span` is by creating a valid tracy zone context.
             // TODO: verify if we need to shift by 8 or not...?
@@ -174,7 +152,6 @@ impl Span {
 
 impl Drop for Span {
     fn drop(&mut self) {
-        #[cfg(feature = "enable")]
         unsafe {
             // SAFE: The only way to construct `Span` is by creating a valid tracy zone context. We
             // also still have an owned Client handle.


### PR DESCRIPTION
This might be a controversial change (and it is breaking), but I think the enable feature is spreading bad practices. If a library/binary uses this crate's enable feature, it is still bringing in all the dependencies and build time to set up this crate only to have it be mostly empty. The correct way to use this crate would be to have a tracing feature in user's crates that conditionally enables this one, that way no trace (pun intended) of this crate or its dependencies remains in a production build.

Furthermore, for devs of this crate obeying the enable feature complicates reasoning around structs and the code in general.