### PR TITLE
Minimize tracing-tracy allocations

### DIFF
--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -125,7 +125,8 @@ fn benchmark_span(c: &mut Criterion) {
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                let _span = tracing::error_span!("message").entered();
+                let _span =
+                    tracing::error_span!("message", field1 = "first", field2 = "second").entered();
             });
         });
     });
@@ -135,7 +136,8 @@ fn benchmark_span(c: &mut Criterion) {
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                let _span = tracing::error_span!("message").entered();
+                let _span =
+                    tracing::error_span!("message", field1 = "first", field2 = "second").entered();
             });
         });
     });
@@ -147,7 +149,7 @@ fn benchmark_message(c: &mut Criterion) {
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                tracing::error!("message");
+                tracing::error!(field1 = "first", field2 = "second", "message");
             });
         });
     });
@@ -157,7 +159,7 @@ fn benchmark_message(c: &mut Criterion) {
             tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
-                tracing::error!("message");
+                tracing::error!(field1 = "first", field2 = "second", "message");
             });
         });
     });


### PR DESCRIPTION
~~Depends on https://github.com/nagisa/rust_tracy_client/pull/85. Will rebase once that's in.~~ Done.

---

~~Note that the two commits should NOT be squashed as the second one contains benchmarking code.~~

Turns out GitHub [saves the PR history](https://stackoverflow.com/a/56632574/4548500) even when squashing, so nevermind since I feel like these commits are messier.

---

The one major downside of this caching is that for long-running applications which occasionally have super long field values, we have no way of reclaiming that memory. I think that's ok until someone actually runs into this issue and can tell us more about their needs. For example, maybe we offer a "clear cache" API that they could run? Or maybe they need to configure the max cache size? Not sure, so probs easiest to wait unless you think this needs to be solved (in which case I'd rather do that in a follow up PR). TL;DR: the memory usage currently scales as O(num_active_spans*max_field_value_length).

---

The results are in: almost double the performance!

> Note that I'm testing this with https://github.com/nagisa/rust_tracy_client/pull/87 as I'll deal with the `format!` allocation once we have a path forward there. 

```
~> tracy-capture -o ~/Desktop/ftzz4.tracy -f
Connecting to 127.0.0.1:8086...
Queue delay: 19 ns
Timer resolution: 19 ns
 471.09 Mbps / 18.8% =2501.45 Mbps | Tx: 563 MB | 1020.05 MB | 10.21 s
Frames: 2
Time span: 10.25 s
Zones: 4,033,823
Elapsed time: 9.93 s
Saving trace... done!
Trace size 282.4 MB (37.28% ratio)
~> tracy-capture -o ~/Desktop/ftzz5.tracy -f
Connecting to 127.0.0.1:8086...
Queue delay: 21 ns
Timer resolution: 21 ns
 498.87 Mbps / 18.2% =2744.67 Mbps | Tx: 366.32 MB | 722.33 MB | 6.67 s
Frames: 2
Time span: 6.69 s
Zones: 4,033,813
Elapsed time: 6.41 s
Saving trace... done!
Trace size 193.94 MB (34.32% ratio)
```

Before:
![image](https://github.com/nagisa/rust_tracy_client/assets/9490724/09058dfb-3652-423f-9e12-8c33a87e27be)

After:
![image](https://github.com/nagisa/rust_tracy_client/assets/9490724/c2e646ad-0a38-49df-964a-d63a5ccdad2f)
