### PR TITLE
Turn configuration options into const generic params

### DIFF
--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -124,7 +124,7 @@ pub(crate) fn test() {
 fn benchmark_span(c: &mut Criterion) {
     c.bench_function("span/callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<100>());
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -135,7 +135,7 @@ fn benchmark_span(c: &mut Criterion) {
 
     c.bench_function("span/no_callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<0>());
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -148,7 +148,7 @@ fn benchmark_span(c: &mut Criterion) {
 fn benchmark_message(c: &mut Criterion) {
     c.bench_function("event/callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<100>());
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");
@@ -158,7 +158,7 @@ fn benchmark_message(c: &mut Criterion) {
 
     c.bench_function("event/no_callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<0>());
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");

--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -4,6 +4,8 @@ use tracing::{debug, event, info, info_span, span, Level};
 use tracing_attributes::instrument;
 use tracing_subscriber::layer::SubscriberExt;
 
+use crate::config::ZeroU16;
+
 fn it_works() {
     let span = span!(Level::TRACE, "a sec");
     let _enter = span.enter();
@@ -124,7 +126,7 @@ pub(crate) fn test() {
 fn benchmark_span(c: &mut Criterion) {
     c.bench_function("span/callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<100>());
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -135,7 +137,7 @@ fn benchmark_span(c: &mut Criterion) {
 
     c.bench_function("span/no_callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<0>());
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth(ZeroU16));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -148,7 +150,7 @@ fn benchmark_span(c: &mut Criterion) {
 fn benchmark_message(c: &mut Criterion) {
     c.bench_function("event/callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<100>());
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth(100));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");
@@ -158,7 +160,7 @@ fn benchmark_message(c: &mut Criterion) {
 
     c.bench_function("event/no_callstack", |bencher| {
         let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth::<0>());
+            tracing_subscriber::registry().with(super::TracyLayer::new().with_stack_depth(ZeroU16));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");


### PR DESCRIPTION
Depends on https://github.com/nagisa/rust_tracy_client/pull/87.

This is a bit of a _so preoccupied with whether they could, they didn’t stop to think if they should_ moment, but I realized we can make our primitive config options const generic params. The benefit is that the optimizer can eliminate a bunch of branches and dead code that would have been very hard to prove safe to remove before. There's precedent for doing something similar in other crates: https://docs.rs/sharded-slab/0.1.7/sharded_slab/pool/struct.Pool.html#method.new_with_config.

Also, I don't think this makes the API worse, it's basically just different syntax (unless you want this stuff to be dynamic in which case you're screwed):
```rust
   tracing_tracy::TracyLayer::new()
                        .with_stack_depth::<32>()
                        .with_fields_in_zone_name::<false>(),
```


Thoughts?