### PR TITLE
tracing-tracy: replace baked-in config fields with a `Config` trait

### DIFF
--- a/tracing-tracy/src/config.rs
+++ b/tracing-tracy/src/config.rs
@@ -56,6 +56,26 @@ pub trait Config {
     fn format_fields_in_zone_name(&self) -> bool {
         true
     }
+
+    /// Apply handling for errors detected by the [`TracyLayer`].
+    ///
+    /// Fundamentally the way the tracing crate and the Tracy profiler work are somewhat
+    /// incompatible in certain ways. For instance, a [`tracing::Span`] can be created on one
+    /// thread and moved to another, where it is cleaned up. Tracy on the other hand expects that
+    /// its eqvivalent concept of zone remains entirely within a thread.
+    ///
+    /// Another example a limitation in `Tracy` where the message length or zone name cannot exceed
+    /// a certain (low) limit of bytes.
+    ///
+    /// Although `tracing_tracy` does it best to paper over these sorts of differences, it can’t
+    /// always make them invisible. In certain cases detecting these sorts of issues is
+    /// straightforward, and it is when `tracing_tracy` will invoke this method to enable users to
+    /// report the issues in whatever way they wish to.
+    ///
+    /// By default a message coloured in red is emitted to the tracy client.
+    fn on_error(&self, client: &Client, error: &'static str) {
+        client.color_message(error, 0xFF000000, self.stack_depth());
+    }
 }
 
 /// A type that implements the [`Config`] trait with runtime-adjustable values.

--- a/tracing-tracy/src/config.rs
+++ b/tracing-tracy/src/config.rs
@@ -1,10 +1,8 @@
 use client::Client;
 use tracing_subscriber::fmt::format::DefaultFields;
 use tracing_subscriber::fmt::FormatFields;
-#[allow(unused_imports)] // for documentation.
-use super::TracyLayer;
 
-/// Configuration of the [`TracyLayer`] behaviour.
+/// Configuration of the [`TracyLayer`](super::TracyLayer) behaviour.
 ///
 /// For most users [`DefaultConfig`] is going to be a good default choice, however advanced users
 /// can implement this trait manually to override the formatter used or to otherwise modify the
@@ -26,11 +24,11 @@ use super::TracyLayer;
 ///     // The boilerplate ends here
 ///
 ///     /// Collect 32 frames in stack traces.
-///     fn stack_depth(&self) -> u16 {
+///     fn stack_depth(&self, _: &tracing::Metadata) -> u16 {
 ///         32
 ///     }
 ///
-///     /// Do not format in fields into zone names.
+///     /// Do not format fields into zone names.
 ///     fn format_fields_in_zone_name(&self) -> bool {
 ///         false
 ///     }
@@ -53,7 +51,8 @@ pub trait Config {
     /// every instrumentation point. Specifying 0 frames will disable stack trace collection.
     ///
     /// Default implementation returns `0`.
-    fn stack_depth(&self) -> u16 {
+    fn stack_depth(&self, metadata: &tracing_core::Metadata<'_>) -> u16 {
+        let _ = metadata;
         0
     }
 
@@ -69,7 +68,7 @@ pub trait Config {
         true
     }
 
-    /// Apply handling for errors detected by the [`TracyLayer`].
+    /// Apply handling for errors detected by the [`TracyLayer`](super::TracyLayer).
     ///
     /// Fundamentally the way the tracing crate and the Tracy profiler work are somewhat
     /// incompatible in certain ways. For instance, a [`tracing::Span`] can be created on one
@@ -86,11 +85,11 @@ pub trait Config {
     ///
     /// By default a message coloured in red is emitted to the tracy client.
     fn on_error(&self, client: &Client, error: &'static str) {
-        client.color_message(error, 0xFF000000, self.stack_depth());
+        client.color_message(error, 0xFF000000, 0);
     }
 }
 
-/// A default configuration of the [`TracyLayer`].
+/// A default configuration of the [`TracyLayer`](super::TracyLayer).
 ///
 /// This type does not allow for any adjustment of the configuration. In order to customize
 /// the behaviour of the layer implement the [`Config`] trait for your own type.

--- a/tracing-tracy/src/config.rs
+++ b/tracing-tracy/src/config.rs
@@ -1,0 +1,123 @@
+use client::Client;
+use tracing_subscriber::fmt::format::DefaultFields;
+use tracing_subscriber::fmt::FormatFields;
+
+/// Configuration of the [`TracyLayer`] behaviour.
+///
+/// For most users [`DynamicConfig`] is going to be a good default option, however advanced users
+/// can implement this trait manually to achieve better performance through constant evaluation,
+/// to override the formatter used or to otherwise modify the behaviour of `TracyLayer` in ways
+/// that are not exposed via the `DynamicConfig` type.
+///
+/// # Examples
+///
+/// ## Implementation with compile-time configuration
+///
+/// ```
+/// #[derive(Default)]
+/// struct ConstantTracyConfig {
+///     formatter: tracing_subscriber::fmt::format::DefaultFields,
+/// }
+///
+/// impl tracing_tracy::Config for ConstantTracyConfig {
+///     type Formatter = tracing_subscriber::fmt::format::DefaultFields;
+///     fn formatter(&self) -> &Self::Formatter { &self.formatter }
+///     fn stack_depth(&self) -> u16 { 0 } // Same as the default trait impl.
+///     fn format_fields_in_zone_name(&self) -> bool { true } // Same as the default trait impl.
+/// }
+/// ```
+///
+/// With this sort of setup the compiler will be able to inline calls to `stack_depth` and
+/// `format_fields_in_zone_name` and optimize accordingly.
+pub trait Config {
+    type Formatter: for<'writer> FormatFields<'writer> + 'static;
+
+    /// Use a custom field formatting implementation.
+    fn formatter(&self) -> &Self::Formatter;
+
+    /// Specify the maximum number of stack frames that will be collected.
+    ///
+    /// Note that enabling callstack collection can and will introduce a non-trivial overhead at
+    /// every instrumentation point. Specifying 0 frames will disable stack trace collection.
+    ///
+    /// Default implementation returns `0`.
+    fn stack_depth(&self) -> u16 {
+        0
+    }
+
+    /// Specify whether or not to include tracing span fields in the tracy zone name, or to emit
+    /// them as zone text.
+    ///
+    /// The former enables zone analysis along unique span field invocations, while the latter
+    /// aggregates every invocation of a given span into a single zone, irrespective of field
+    /// values.
+    ///
+    /// Default implementation returns `true`.
+    fn format_fields_in_zone_name(&self) -> bool {
+        true
+    }
+}
+
+/// A type that implements the [`Config`] trait with runtime-adjustable values.
+///
+/// Ues the [`tracing_subscriber`] [`DefaultFields`] formatter. If not appropriate, consider
+/// implementing the `Config` trait yourself.
+pub struct DynamicConfig {
+    fmt: DefaultFields,
+    stack_depth: u16,
+    fields_in_zone_name: bool,
+}
+
+impl DynamicConfig {
+    /// Create a new implementation of `Config` that permits non-constant configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        DynamicConfig {
+            fmt: DefaultFields::new(),
+            stack_depth: 0,
+            fields_in_zone_name: true,
+        }
+    }
+
+    /// Specify the maximum number of stack frames that will be collected.
+    ///
+    /// Note that enabling callstack collection can and will introduce a non-trivial overhead at
+    /// every instrumentation point. Specifying 0 frames will disable stack trace collection.
+    ///
+    /// Defaults to `0`.
+    #[must_use]
+    pub const fn with_stack_depth(mut self, stack_depth: u16) -> Self {
+        self.stack_depth = stack_depth;
+        self
+    }
+
+    /// Specify whether or not to include tracing span fields in the tracy zone name, or to emit
+    /// them as zone text.
+    ///
+    /// The former enables zone analysis along unique span field invocations, while the latter
+    /// aggregates every invocation of a given span into a single zone, irrespective of field
+    /// values.
+    ///
+    /// Defaults to `true`.
+    #[must_use]
+    pub const fn with_fields_in_zone_name(mut self, fields_in_zone_name: bool) -> Self {
+        self.fields_in_zone_name = fields_in_zone_name;
+        self
+    }
+}
+
+impl Config for DynamicConfig {
+    type Formatter = DefaultFields;
+
+    fn formatter(&self) -> &Self::Formatter {
+        &self.fmt
+    }
+
+    fn stack_depth(&self) -> u16 {
+        self.stack_depth
+    }
+
+    fn format_fields_in_zone_name(&self) -> bool {
+        self.fields_in_zone_name
+    }
+}

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -49,7 +49,7 @@
 #![cfg_attr(tracing_tracy_docs, feature(doc_auto_cfg))]
 
 use client::{Client, Span};
-pub use config::{Config, DynamicConfig};
+pub use config::{Config, DefaultConfig};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt::Write, mem};
 use tracing_core::{
@@ -85,7 +85,7 @@ thread_local! {
 /// ).expect("setup tracy layer");
 /// ```
 #[derive(Clone)]
-pub struct TracyLayer<C = DynamicConfig> {
+pub struct TracyLayer<C = DefaultConfig> {
     config: C,
     client: Client,
 }
@@ -139,7 +139,7 @@ impl<C: Config> TracyLayer<C> {
 
 impl Default for TracyLayer {
     fn default() -> Self {
-        Self::new(DynamicConfig::new())
+        Self::new(DefaultConfig::default())
     }
 }
 

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -133,8 +133,7 @@ impl<C: Config> TracyLayer<C> {
             while !data.is_char_boundary(max_len) {
                 max_len -= 1;
             }
-            self.client
-                .color_message(error_msg, 0xFF000000, self.config.stack_depth());
+            self.config.on_error(&self.client, error_msg);
             &data[..max_len]
         } else {
             data
@@ -294,19 +293,17 @@ where
 
         if let Some((span, span_id)) = stack_frame {
             if id.into_u64() != span_id {
-                self.client.color_message(
+                self.config.on_error(
+                    &self.client,
                     "Tracing spans exited out of order! \
-                        Trace may not be accurate for this span stack.",
-                    0xFF000000,
-                    self.config.stack_depth(),
+                        Trace might not be accurate for this span stack.",
                 );
             }
             drop(span);
         } else {
-            self.client.color_message(
+            self.config.on_error(
+                &self.client,
                 "Exiting a tracing span, but got nothing on the tracy span stack!",
-                0xFF000000,
-                self.config.stack_depth(),
             );
         }
     }

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -26,9 +26,7 @@
 //! use tracing_subscriber::layer::SubscriberExt;
 //!
 //! tracing::subscriber::set_global_default(
-//!     tracing_subscriber::registry().with(
-//!         tracing_tracy::TracyLayer::new(tracing_tracy::DynamicConfig::new())
-//!     )
+//!     tracing_subscriber::registry().with(tracing_tracy::TracyLayer::default())
 //! ).expect("setup tracy layer");
 //! ```
 //!
@@ -83,9 +81,7 @@ thread_local! {
 /// ```rust
 /// use tracing_subscriber::layer::SubscriberExt;
 /// tracing::subscriber::set_global_default(
-///     tracing_subscriber::registry().with(
-///         tracing_tracy::TracyLayer::new(tracing_tracy::DynamicConfig::new())
-///     )
+///     tracing_subscriber::registry().with(tracing_tracy::TracyLayer::default())
 /// ).expect("setup tracy layer");
 /// ```
 #[derive(Clone)]

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -223,7 +223,7 @@ where
                         visitor.dest,
                         "event message is too long and was truncated",
                     ),
-                    self.config.stack_depth(),
+                    self.config.stack_depth(event.metadata()),
                 );
             }
             if visitor.frame_mark {
@@ -253,7 +253,7 @@ where
                         "",
                         file,
                         line,
-                        self.config.stack_depth(),
+                        self.config.stack_depth(metadata),
                     ),
                     id.into_u64(),
                 )

--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -131,7 +131,7 @@ impl Config for CallstackConfig {
     fn formatter(&self) -> &Self::Formatter {
         self.0.formatter()
     }
-    fn stack_depth(&self) -> u16 {
+    fn stack_depth(&self, _: &tracing_core::Metadata<'_>) -> u16 {
         100
     }
 }

--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -104,7 +104,7 @@ fn span_with_fields() {
 
 pub(crate) fn test() {
     tracing::subscriber::set_global_default(
-        tracing_subscriber::registry().with(TracyLayer::new(DynamicConfig::new())),
+        tracing_subscriber::registry().with(TracyLayer::default()),
     )
     .expect("setup the subscriber");
     it_works();
@@ -158,7 +158,8 @@ fn benchmark_message(c: &mut Criterion) {
     });
 
     c.bench_function("event/no_callstack", |bencher| {
-        let layer = tracing_subscriber::registry().with(TracyLayer::new(DynamicConfig::new().with_stack_depth(0)));
+        let layer = tracing_subscriber::registry()
+            .with(TracyLayer::new(DynamicConfig::new().with_stack_depth(0)));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");

--- a/tracing-tracy/src/tests.rs
+++ b/tracing-tracy/src/tests.rs
@@ -1,3 +1,4 @@
+use super::{DynamicConfig, TracyLayer};
 use criterion::Criterion;
 use futures::future::join_all;
 use tracing::{debug, event, info, info_span, span, Level};
@@ -103,7 +104,7 @@ fn span_with_fields() {
 
 pub(crate) fn test() {
     tracing::subscriber::set_global_default(
-        tracing_subscriber::registry().with(super::TracyLayer::new()),
+        tracing_subscriber::registry().with(TracyLayer::new(DynamicConfig::new())),
     )
     .expect("setup the subscriber");
     it_works();
@@ -123,8 +124,8 @@ pub(crate) fn test() {
 
 fn benchmark_span(c: &mut Criterion) {
     c.bench_function("span/callstack", |bencher| {
-        let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
+        let layer = tracing_subscriber::registry()
+            .with(TracyLayer::new(DynamicConfig::new().with_stack_depth(100)));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -134,8 +135,8 @@ fn benchmark_span(c: &mut Criterion) {
     });
 
     c.bench_function("span/no_callstack", |bencher| {
-        let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
+        let layer = tracing_subscriber::registry()
+            .with(TracyLayer::new(DynamicConfig::new().with_stack_depth(0)));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 let _span =
@@ -147,8 +148,8 @@ fn benchmark_span(c: &mut Criterion) {
 
 fn benchmark_message(c: &mut Criterion) {
     c.bench_function("event/callstack", |bencher| {
-        let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(100));
+        let layer = tracing_subscriber::registry()
+            .with(TracyLayer::new(DynamicConfig::new().with_stack_depth(100)));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");
@@ -157,8 +158,7 @@ fn benchmark_message(c: &mut Criterion) {
     });
 
     c.bench_function("event/no_callstack", |bencher| {
-        let layer =
-            tracing_subscriber::registry().with(super::TracyLayer::new().with_stackdepth(0));
+        let layer = tracing_subscriber::registry().with(TracyLayer::new(DynamicConfig::new().with_stack_depth(0)));
         tracing::subscriber::with_default(layer, || {
             bencher.iter(|| {
                 tracing::error!(field1 = "first", field2 = "second", "message");


### PR DESCRIPTION
This allows users to more flexibly adjust the behaviour of the tracing layer. My favourite examples are actually an ability to implement this structure for some other serialization format that holds the application-wide config. That way people do not need to litter their application set up code with accesses to their configuration, conversion and other concerns.

But with this if people want constant evaluation for performance critical applications, now they can do it too.