### PR TITLE
Add demangling feature and implementation

### DIFF
--- a/FEATURES.mkd
+++ b/FEATURES.mkd
@@ -31,13 +31,9 @@
   `TRACY_NO_CALLSTACK_INLINES` define.
 * `delayed-init` – initializes trace structures upon a first request, rather than at load time.
   Corresponds to the `TRACY_DELAYED_INIT` define.
-* `demangle` - requires that the demangling function (`___tracy_demangle`) be defined by the user.
-  A default one is provided with the `demangle-impl` feature.
+* `demangle` - requires that the demangling function be defined by the user.
+  See the `register_demangler!` macro for more details.
   Corresponds to the `TRACY_DEMANGLE` define.
-* `demangle-impl` - provides a custom demangling function to demangle Rust symbols.
-  The implementation is provided in `tracy-client` using [`rustc-demangle`].
 
 Refer to this package's `Cargo.toml` for the list of the features enabled by default. Refer to
 the `Tracy` manual for more information on the implications of each feature.
-
-[`rustc-demangle`]: https://crates.io/crates/rustc-demangle

--- a/FEATURES.mkd
+++ b/FEATURES.mkd
@@ -30,7 +30,14 @@
   the profiler use the basic but much faster frame resolution mode. Corresponds to the
   `TRACY_NO_CALLSTACK_INLINES` define.
 * `delayed-init` – initializes trace structures upon a first request, rather than at load time.
-  Corresponds to thw `TRACY_DELAYED_INIT` define.
+  Corresponds to the `TRACY_DELAYED_INIT` define.
+* `demangle` - requires that the demangling function (`___tracy_demangle`) be defined by the user.
+  A default one is provided with the `demangle-impl` feature.
+  Corresponds to the `TRACY_DEMANGLE` define.
+* `demangle-impl` - provides a custom demangling function to demangle Rust symbols.
+  The implementation is provided in `tracy-client` using [`rustc-demangle`].
 
 Refer to this package's `Cargo.toml` for the list of the features enabled by default. Refer to
 the `Tracy` manual for more information on the implications of each feature.
+
+[`rustc-demangle`]: https://crates.io/crates/rustc-demangle

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -33,7 +33,7 @@ criterion = "0.5"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
+            "broadcast", "callstack-inlines", "demangle", "demangle-impl" ]
 broadcast = ["client/broadcast"]
 code-transfer = ["client/code-transfer"]
 context-switch-tracing = ["client/context-switch-tracing"]
@@ -49,6 +49,8 @@ callstack-inlines = ["client/callstack-inlines"]
 manual-lifetime = ["client/manual-lifetime"]
 delayed-init = ["client/delayed-init"]
 flush-on-exit = ["client/flush-on-exit"]
+demangle = ["client/demangle"]
+demangle-impl = ["client/demangle-impl"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -33,7 +33,7 @@ criterion = "0.5"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines", "demangle", "demangle-impl" ]
+            "broadcast", "callstack-inlines" ]
 broadcast = ["client/broadcast"]
 code-transfer = ["client/code-transfer"]
 context-switch-tracing = ["client/context-switch-tracing"]
@@ -50,7 +50,6 @@ manual-lifetime = ["client/manual-lifetime"]
 delayed-init = ["client/delayed-init"]
 flush-on-exit = ["client/flush-on-exit"]
 demangle = ["client/demangle"]
-demangle-impl = ["client/demangle-impl"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -44,6 +44,7 @@ manual-lifetime = ["delayed-init"]
 delayed-init = []
 callstack-inlines = []
 flush-on-exit = []
+demangle = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -42,6 +42,9 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
     if std::env::var_os("CARGO_FEATURE_FLUSH_ON_EXIT").is_some() {
         c.define("TRACY_NO_EXIT", None);
     }
+    if std::env::var_os("CARGO_FEATURE_DEMANGLE").is_some() {
+        c.define("TRACY_DEMANGLE", None);
+    }
 
     // Note: these are inversed and check for `is_none`!
     if std::env::var_os("CARGO_FEATURE_SYSTEM_TRACING").is_none() {

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.7"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines", "demangle" ]
+            "broadcast", "callstack-inlines" ]
 broadcast = ["sys/broadcast"]
 code-transfer = ["sys/code-transfer"]
 context-switch-tracing = ["sys/context-switch-tracing"]
@@ -63,8 +63,7 @@ callstack-inlines = ["sys/callstack-inlines"]
 manual-lifetime = ["sys/manual-lifetime"]
 delayed-init = ["sys/delayed-init"]
 flush-on-exit = ["sys/flush-on-exit"]
-demangle = ["sys/demangle"]
-demangle-impl = ["demangle", "dep:rustc-demangle"]
+demangle = ["sys/demangle", "dep:rustc-demangle"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -33,6 +33,7 @@ criterion = "0.5"
 
 [dependencies]
 once_cell = "1.19"
+rustc-demangle = { version = "0.1", optional = true }
 
 [dependencies.sys]
 path = "../tracy-client-sys"
@@ -46,7 +47,7 @@ version = "0.7"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
+            "broadcast", "callstack-inlines", "demangle" ]
 broadcast = ["sys/broadcast"]
 code-transfer = ["sys/code-transfer"]
 context-switch-tracing = ["sys/context-switch-tracing"]
@@ -62,6 +63,8 @@ callstack-inlines = ["sys/callstack-inlines"]
 manual-lifetime = ["sys/manual-lifetime"]
 delayed-init = ["sys/delayed-init"]
 flush-on-exit = ["sys/flush-on-exit"]
+demangle = ["sys/demangle"]
+demangle-impl = ["demangle", "dep:rustc-demangle"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -53,6 +53,9 @@ pub mod internal {
     use std::ffi::CString;
     pub use std::ptr::null;
 
+    #[cfg(feature = "demangle")]
+    pub use rustc_demangle;
+
     #[inline(always)]
     #[must_use]
     pub fn make_span_location(
@@ -298,39 +301,59 @@ pub(crate) const fn adjust_stack_depth(depth: u16) -> u16 {
     }
 }
 
-/// The custom demangling function.
-#[cfg(feature = "demangle-impl")]
-#[no_mangle]
-#[allow(static_mut_refs)]
-unsafe extern "C" fn ___tracy_demangle(
-    mangled: *const std::ffi::c_char,
-) -> *const std::ffi::c_char {
-    use std::fmt::Write;
-    use std::ptr::null;
+/// Registers a custom demangler function.
+///
+/// By default, Tracy demangles symbols using the C++ ABI, which is not fully compatible with Rust
+/// symbol mangling.
+///
+/// With the `demangle` feature enabled, clients must register a custom demangling function.
+///
+/// A default implementation using the `rustc_demangle` crate can be registered using this macro.
+///
+/// In the future, this macro may be expanded to support a custom demangler function.
+#[cfg(feature = "demangle")]
+#[macro_export]
+macro_rules! register_demangler {
+    () => {
+        const _: () = {
+            #[no_mangle]
+            #[allow(static_mut_refs)]
+            unsafe extern "C" fn ___tracy_demangle(
+                mangled: *const std::ffi::c_char,
+            ) -> *const std::ffi::c_char {
+                use std::fmt::Write;
+                use std::ptr::null;
 
-    // https://github.com/wolfpld/tracy/blob/d4a4b623968d99a7403cd93bae5247ed0735680a/public/client/TracyCallstack.cpp#L57-L67
-    // > The demangling function is responsible for managing memory for this string.
-    // > It is expected that it will be internally reused.
-    // > When a call to ___tracy_demangle is made, previous contents of the string memory
-    // > do not need to be preserved.
-    static mut BUFFER: String = String::new();
+                // https://github.com/wolfpld/tracy/blob/d4a4b623968d99a7403cd93bae5247ed0735680a/public/client/TracyCallstack.cpp#L57-L67
+                // > The demangling function is responsible for managing memory for this string.
+                // > It is expected that it will be internally reused.
+                // > When a call to ___tracy_demangle is made, previous contents of the string memory
+                // > do not need to be preserved.
+                static mut BUFFER: String = String::new();
 
-    if mangled.is_null() {
-        return null();
-    }
-    let cstr = unsafe { std::ffi::CStr::from_ptr(mangled) };
-    let Ok(str) = cstr.to_str() else {
-        return null();
+                if mangled.is_null() {
+                    return null();
+                }
+                let cstr = unsafe { std::ffi::CStr::from_ptr(mangled) };
+                let Ok(str) = cstr.to_str() else {
+                    return null();
+                };
+                let Ok(demangled) = $crate::internal::rustc_demangle::try_demangle(str) else {
+                    return null();
+                };
+                let buffer = unsafe { &mut BUFFER };
+                let prev_len = buffer.len();
+                // Use `:#` formatting to elide the hash.
+                if write!(buffer, "{demangled:#}\0").is_err() {
+                    buffer.truncate(prev_len);
+                    return null();
+                }
+                buffer[prev_len..].as_ptr().cast()
+            }
+        };
     };
-    let Ok(demangled) = rustc_demangle::try_demangle(str) else {
-        return null();
+
+    ($path:path) => {
+        compile_error!("custom demangler functions are not yet supported");
     };
-    let buffer = unsafe { &mut BUFFER };
-    let prev_len = buffer.len();
-    // Use `:#` formatting to elide the hash.
-    if write!(buffer, "{demangled:#}\0").is_err() {
-        buffer.truncate(prev_len);
-        return null();
-    }
-    buffer[prev_len..].as_ptr().cast()
 }


### PR DESCRIPTION
Adds the `demangle` feature to define `TRACY_DEMANGLE`, as well as `demangle-impl` to define a default implementation that demangles Rust symbols using [`rustc-demangle`](https://crates.io/crates/rustc-demangle).

I thought it would be useful to have the C define feature separated from the implementation in case a user would want to define their own.

---

Before: 
![image](https://github.com/nagisa/rust_tracy_client/assets/57450786/42363ecf-d60e-4335-99fc-ea4f41b071ca)

After: 
![image](https://github.com/nagisa/rust_tracy_client/assets/57450786/cfcc07be-d5b7-4e71-a59e-3f22c2386062)
