### PR TITLE
Set `TRACY_NO_VERIFY` to reduce instrumentation overhead

### DIFF
--- a/FEATURES.mkd
+++ b/FEATURES.mkd
@@ -34,6 +34,7 @@
 * `demangle` - requires that the demangling function be defined by the user.
   See the `register_demangler!` macro for more details.
   Corresponds to the `TRACY_DEMANGLE` define.
+* `no-verify` - disables verification that spans are closed within Tracy's C API. Enabling this significantly reduces the relative overhead and timing precision of short lived spans (<100ns) - but can cause undefined behavior if spans are not closed, when using the Rust API this would likely correspond to calling a `std::mem::forget(span)`. Corresponds to the `TRACY_NO_VERIFY` define. 
 
 Refer to this package's `Cargo.toml` for the list of the features enabled by default. Refer to
 the `Tracy` manual for more information on the implications of each feature.

--- a/FEATURES.mkd
+++ b/FEATURES.mkd
@@ -34,7 +34,12 @@
 * `demangle` - requires that the demangling function be defined by the user.
   See the `register_demangler!` macro for more details.
   Corresponds to the `TRACY_DEMANGLE` define.
-* `no-verify` - disables verification that spans are closed within Tracy's C API. Enabling this significantly reduces the relative overhead and timing precision of short lived spans (<100ns) - but can cause undefined behavior if spans are not closed, when using the Rust API this would likely correspond to calling a `std::mem::forget(span)`. Corresponds to the `TRACY_NO_VERIFY` define. 
+* `verify` - enables verification that spans are closed within Tracy's C API. Disabling this
+  reduces instrumentation overhead (~50% for 0 callstack depth spans) and improves timing precision
+  by a proportional amount. This is most noticeable in short lived spans (<100ns) but can cause
+  undefined behavior if spans are not closed. When using the provided Rust APIs this can occur if a
+  Span's drop code is not called (e.g. `std::mem::forget(span)`). When disabled
+  corresponds to the `TRACY_NO_VERIFY` define.
 
 Refer to this package's `Cargo.toml` for the list of the features enabled by default. Refer to
 the `Tracy` manual for more information on the implications of each feature.

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -50,6 +50,7 @@ manual-lifetime = ["client/manual-lifetime"]
 delayed-init = ["client/delayed-init"]
 flush-on-exit = ["client/flush-on-exit"]
 demangle = ["client/demangle"]
+no-verify = ["client/no-verify"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -50,7 +50,7 @@ manual-lifetime = ["client/manual-lifetime"]
 delayed-init = ["client/delayed-init"]
 flush-on-exit = ["client/flush-on-exit"]
 demangle = ["client/demangle"]
-no-verify = ["client/no-verify"]
+verify = ["client/verify"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -45,7 +45,7 @@ delayed-init = []
 callstack-inlines = []
 flush-on-exit = []
 demangle = []
-no-verify = []
+verify = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -45,6 +45,7 @@ delayed-init = []
 callstack-inlines = []
 flush-on-exit = []
 demangle = []
+no-verify = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -15,6 +15,7 @@ fn link_dependencies() {
 }
 
 fn set_feature_defines(mut c: cc::Build) -> cc::Build {
+    c.define("TRACY_NO_VERIFY", None);
     if std::env::var_os("CARGO_FEATURE_ENABLE").is_some() {
         c.define("TRACY_ENABLE", None);
     }

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -15,9 +15,11 @@ fn link_dependencies() {
 }
 
 fn set_feature_defines(mut c: cc::Build) -> cc::Build {
-    c.define("TRACY_NO_VERIFY", None);
     if std::env::var_os("CARGO_FEATURE_ENABLE").is_some() {
         c.define("TRACY_ENABLE", None);
+    }
+    if std::env::var_os("CARGO_FEATURE_NO_VERIFY").is_some() {
+        c.define("TRACY_NO_VERIFY", None);
     }
     if std::env::var_os("CARGO_FEATURE_TIMER_FALLBACK").is_some() {
         c.define("TRACY_TIMER_FALLBACK", None);

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -18,9 +18,6 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
     if std::env::var_os("CARGO_FEATURE_ENABLE").is_some() {
         c.define("TRACY_ENABLE", None);
     }
-    if std::env::var_os("CARGO_FEATURE_NO_VERIFY").is_some() {
-        c.define("TRACY_NO_VERIFY", None);
-    }
     if std::env::var_os("CARGO_FEATURE_TIMER_FALLBACK").is_some() {
         c.define("TRACY_TIMER_FALLBACK", None);
     }
@@ -67,6 +64,9 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
     }
     if std::env::var_os("CARGO_FEATURE_CALLSTACK_INLINES").is_none() {
         c.define("TRACY_NO_CALLSTACK_INLINES", None);
+    }
+    if std::env::var_os("CARGO_FEATURE_VERIFY").is_none() {
+        c.define("TRACY_NO_VERIFY", None);
     }
     c
 }

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -64,6 +64,7 @@ manual-lifetime = ["sys/manual-lifetime"]
 delayed-init = ["sys/delayed-init"]
 flush-on-exit = ["sys/flush-on-exit"]
 demangle = ["sys/demangle", "dep:rustc-demangle"]
+no-verify = ["sys/no-verify"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -64,7 +64,7 @@ manual-lifetime = ["sys/manual-lifetime"]
 delayed-init = ["sys/delayed-init"]
 flush-on-exit = ["sys/flush-on-exit"]
 demangle = ["sys/demangle", "dep:rustc-demangle"]
-no-verify = ["sys/no-verify"]
+verify = ["sys/verify"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]


### PR DESCRIPTION
Currently the `TRACY_NO_VERIFY` flag is being defaulted to `false`.

As per the Tracy Profiler User Manual
> Since all C API instrumentation has to be done by hand, it is possible to miss some code paths where a
zone should be started or ended. Tracy will perform additional validation of instrumentation correctness to
prevent bad profiling runs. Read section 4.7 for more information.
However, the validation comes with a performance cost, which you may not want to pay. Therefore, if
you are entirely sure that the instrumentation is not broken in any way, you may use the TRACY_NO_VERIFY
macro, which will disable the validation code.

We are handling the scope lifetimes in rust through the `Span` struct thus I don't think we need this extra protection/overhead and importantly if you check the source code in `TracyProfiler.cpp` some of this work is done after getting the time from the profiler. e.g.
```
#ifndef TRACY_NO_VERIFY
    {
        TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
        tracy::MemWrite( &item->zoneValidation.id, id );
        TracyQueueCommitC( zoneValidationThread );
    }
#endif
    {
        TracyQueuePrepareC( tracy::QueueType::ZoneBegin );
        tracy::MemWrite( &item->zoneBegin.time, tracy::Profiler::GetTime() );
        tracy::MemWrite( &item->zoneBegin.srcloc, (uint64_t)srcloc );
        TracyQueueCommitC( zoneBeginThread );
    }
    return ctx;
}
```
With a one line change to the build.rs this halves the time taken per iteration in the `span_callstack/0` benchmark on my machine and subtracts ~20ns from the timed portion of real spans I'm using in production code.
"span_callstack/0" before:
```
span_callstack/0        time:   [61.739 ns 65.917 ns 70.116 ns]
                        change: [-16.371% -11.778% -7.1771%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```
"span_callstack/0" after:
```
span_callstack/0        time:   [37.138 ns 37.721 ns 38.281 ns]
                        change: [-39.220% -36.368% -33.468%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
```