### PR TITLE
Fix stacktrace issues on Windows

### DIFF
--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["fibers"]
 [dependencies]
 
 [target."cfg(windows)".dependencies]
-windows = { version = "0.58.0", features = ["Win32_Security", "Win32_System_Threading"] }
+windows-targets = ">=0.48, <0.53"
 
 [build-dependencies]
 cc = { version = "1.0.83", default-features = false }

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -22,6 +22,9 @@ required-features = ["fibers"]
 
 [dependencies]
 
+[target."cfg(windows)".dependencies]
+windows = { version = "0.58.0", features = ["Win32_Security", "Win32_System_Threading"] }
+
 [build-dependencies]
 cc = { version = "1.0.83", default-features = false }
 

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -86,6 +86,13 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
 fn build_tracy_client() {
     if std::env::var_os("CARGO_FEATURE_ENABLE").is_some() {
         let mut builder = set_feature_defines(cc::Build::new());
+
+        if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+            // Used for synchronizing access to the `dbghelp.dll` symbol helper.
+            // See the `dbghelp` module for more information.
+            builder.define("TRACY_DBGHELP_LOCK", "RustBacktraceMutex");
+        }
+
         let _ = builder
             .file("tracy/TracyClient.cpp")
             .warnings(false)

--- a/tracy-client-sys/src/dbghelp.rs
+++ b/tracy-client-sys/src/dbghelp.rs
@@ -10,11 +10,25 @@
 //! We set `TRACY_DBGHELP_LOCK=RustBacktraceMutex` in the build script.
 //! Tracy will call [`RustBacktraceMutexInit`], [`RustBacktraceMutexLock`], and [`RustBacktraceMutexUnlock`].
 //! In those functions a handle to the shared named mutex is created, the mutex is locked, and unlocked respectively.
+//!
+//! There is also an issue with initialization between Tracy and `backtrace-rs`.
+//! In particular, the `SymInitialize` function should only be called once per process
+//! and will return an error on subsequent calls.
+//! Both Tracy and `backtrace-rs` ignore errors of the `SymInitialize` function,
+//! so calling it multiple times is not an issue.
+//! But `backtrace-rs` adds `SYMOPT_DEFERRED_LOADS` to the symbol options before initialization,
+//! and adds the directory of all loaded modules (executable and DLLs) to the symbol search path.
+//! That causes the symbols for Rust modules to be found even when the working directory isn't the Cargo target directory.
+//! Tracy doesn't add the `SYMOPT_DEFERRED_LOADS` option and manually loads all modules.
+//! Note that changing the symbol search path doesn't affect modules that were already loaded.
+//!
+//! Therefore, we want `backtrace-rs` to initialize and modify the symbol search path before Tracy.
+//! To do that, a standard library backtrace is captured and resolved in [`RustBacktraceMutexInit`].
 
-use std::io::Write;
+use std::io::{sink, Write};
 use std::sync::atomic::{AtomicPtr, Ordering};
 use windows::core::PCSTR;
-use windows::Win32::Foundation::{FALSE, HANDLE};
+use windows::Win32::Foundation::{GetLastError, ERROR_ALREADY_EXISTS, FALSE, HANDLE};
 use windows::Win32::System::Threading::{
     CreateMutexA, GetCurrentProcessId, ReleaseMutex, WaitForSingleObject, INFINITE,
 };
@@ -28,6 +42,11 @@ static RUST_BACKTRACE_MUTEX: AtomicPtr<core::ffi::c_void> = AtomicPtr::new(std::
 #[no_mangle]
 extern "C" fn RustBacktraceMutexInit() {
     unsafe {
+        // Initialize the `dbghelp.dll` symbol helper by capturing and resolving a backtrace using the standard library.
+        // Since symbol resolution is lazy, the backtrace is written to `sink`, which forces symbol resolution.
+        // Refer to the module documentation on why the standard library should do the initialization instead of Tracy.
+        write!(sink(), "{:?}", std::backtrace::Backtrace::force_capture()).unwrap();
+
         // The name is the same one that the standard library and `backtrace-rs` use
         let mut name = [0; 33];
         let id = GetCurrentProcessId();
@@ -38,6 +57,11 @@ extern "C" fn RustBacktraceMutexInit() {
         // to synchronize access to `dbghelp.dll` functions, which are single threaded.
         let mutex = CreateMutexA(None, FALSE, name).unwrap();
         assert!(!mutex.is_invalid());
+
+        // Initialization of the `dbghelp.dll` symbol helper should have already happened
+        // through the standard library backtrace above.
+        // Therefore, the shared named mutex should already have existed.
+        assert_eq!(GetLastError(), ERROR_ALREADY_EXISTS);
 
         // The old value is ignored because this function is only called once,
         // and normally the handle to the mutex is leaked anyway.

--- a/tracy-client-sys/src/dbghelp.rs
+++ b/tracy-client-sys/src/dbghelp.rs
@@ -1,0 +1,64 @@
+//! On Windows, both Tracy and Rust use the `dbghelp.dll` symbol helper to resolve symbols for stack traces.
+//! `dbghelp.dll` is single threaded and requires synchronization to call any of its functions.
+//!
+//! The Rust standard library includes the `backtrace-rs` crate for capturing and resolving backtraces.
+//! When both the standard library and the `backtrace-rs` crate are used in the same program
+//! they need to synchronize their access to `dbghelp.dll`.
+//! They use a shared named Windows mutex for that, which we will use as well.
+//!
+//! Users of Tracy (like this crate) can define the `TRACY_DBGHELP_LOCK` variable for synchronizing access to `dbghelp.dll`.
+//! We set `TRACY_DBGHELP_LOCK=RustBacktraceMutex` in the build script.
+//! Tracy will call [`RustBacktraceMutexInit`], [`RustBacktraceMutexLock`], and [`RustBacktraceMutexUnlock`].
+//! In those functions a handle to the shared named mutex is created, the mutex is locked, and unlocked respectively.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use windows::core::PCSTR;
+use windows::Win32::Foundation::{FALSE, HANDLE};
+use windows::Win32::System::Threading::{
+    CreateMutexA, GetCurrentProcessId, ReleaseMutex, WaitForSingleObject, INFINITE,
+};
+
+/// Handle to the shared named Windows mutex that synchronizes access to the `dbghelp.dll` symbol helper,
+/// with the standard library and `backtrace-rs`.
+/// Gets initialized by [`RustBacktraceMutexInit`],
+/// and because there is no cleanup function, the handle is leaked.
+static RUST_BACKTRACE_MUTEX: AtomicPtr<core::ffi::c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+#[no_mangle]
+extern "C" fn RustBacktraceMutexInit() {
+    unsafe {
+        // The name is the same one that the standard library and `backtrace-rs` use
+        let mut name = [0; 33];
+        let id = GetCurrentProcessId();
+        write!(&mut name[..], "Local\\RustBacktraceMutex{id:08X}\0").unwrap();
+        let name = PCSTR::from_raw(name.as_ptr());
+
+        // Creates a named mutex that is shared with the standard library and `backtrace-rs`
+        // to synchronize access to `dbghelp.dll` functions, which are single threaded.
+        let mutex = CreateMutexA(None, FALSE, name).unwrap();
+        assert!(!mutex.is_invalid());
+
+        // The old value is ignored because this function is only called once,
+        // and normally the handle to the mutex is leaked anyway.
+        RUST_BACKTRACE_MUTEX.store(mutex.0, Ordering::Release);
+    }
+}
+
+#[no_mangle]
+extern "C" fn RustBacktraceMutexLock() {
+    unsafe {
+        let mutex = HANDLE(RUST_BACKTRACE_MUTEX.load(Ordering::Acquire));
+        assert!(!mutex.is_invalid());
+        WaitForSingleObject(mutex, INFINITE);
+    }
+}
+
+#[no_mangle]
+extern "C" fn RustBacktraceMutexUnlock() {
+    unsafe {
+        let mutex = HANDLE(RUST_BACKTRACE_MUTEX.load(Ordering::Acquire));
+        assert!(!mutex.is_invalid());
+        ReleaseMutex(mutex).unwrap();
+    }
+}

--- a/tracy-client-sys/src/dbghelp.rs
+++ b/tracy-client-sys/src/dbghelp.rs
@@ -68,14 +68,11 @@ extern "C" fn RustBacktraceMutexInit() {
         write!(sink(), "{:?}", std::backtrace::Backtrace::force_capture()).unwrap();
 
         // The name is the same one that the standard library and `backtrace-rs` use
-        let mut name = [0; 33];
-        let id = GetCurrentProcessId();
-        write!(&mut name[..], "Local\\RustBacktraceMutex{id:08X}\0").unwrap();
-        let name: PCSTR = name.as_ptr();
+        let name = format!("Local\\RustBacktraceMutex{:08X}\0", GetCurrentProcessId());
 
         // Creates a named mutex that is shared with the standard library and `backtrace-rs`
         // to synchronize access to `dbghelp.dll` functions, which are single threaded.
-        let mutex = CreateMutexA(std::ptr::null(), FALSE, name);
+        let mutex = CreateMutexA(std::ptr::null(), FALSE, name.as_ptr());
         assert!(mutex != -1 as _ && mutex != 0 as _);
 
         // Initialization of the `dbghelp.dll` symbol helper should have already happened

--- a/tracy-client-sys/src/lib.rs
+++ b/tracy-client-sys/src/lib.rs
@@ -50,3 +50,6 @@ pub use generated_manual_lifetime::*;
 mod generated_fibers;
 #[cfg(all(feature = "enable", feature = "fibers"))]
 pub use generated_fibers::{___tracy_fiber_enter, ___tracy_fiber_leave};
+
+#[cfg(all(feature = "enable", target_os = "windows"))]
+mod dbghelp;


### PR DESCRIPTION
There are 2 issues with capturing stack traces on Windows.
Specifically with the resolving of the symbols of the stack traces.
Note that this affects both the stack traces captured by Rust and Tracy.

Both Rust and Tracy use the `dbghelp.dll` symbol helper to resolve symbols.
The first issue is that `dbghelp.dll` is single threaded and all its functions need to be externally synchronized.
Rust uses a [named Windows mutex to synchronize](https://github.com/rust-lang/backtrace-rs/blob/4f3acf7a0a9f686ec004716e5d514d9732b41486/src/dbghelp.rs#L253) access to `dbghelp.dll` between the standard library and the `backtrace-rs` crate when both are used.
The first commit in this PR makes Tracy use the same named Mutex.
Not properly synchronizing can lead to partially corrupted stacktraces.
<details>
<summary>Example corrupted stacktrace</summary>

Note the `<unknown>` at the top probably caused by some race condition
```
stack backtrace:
   0:     0x7ff7a900767d - <unknown>
   1:     0x7ff7a9014bc9 - <unknown>
   2:     0x7ff7a9006011 - <unknown>
   3:     0x7ff7a90093c7 - <unknown>
   4:     0x7ff7a9008fb9 - <unknown>
   5:     0x7ff7a9009a72 - <unknown>
   6:     0x7ff7a900990f - <unknown>
   7:     0x7ff7a9007d6f - <unknown>
   8:     0x7ff7a9009526 - <unknown>
   9:     0x7ff7a903dbc4 - <unknown>
  10:     0x7ff7a90012ee - tracy_client_stacktrace::main
                               at C:\Dev\tracy-client-stacktrace-issue\src\main.rs:5
  11:     0x7ff7a900138b - core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\ops\function.rs:250
  12:     0x7ff7a900142e - core::hint::black_box
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\hint.rs:389
  13:     0x7ff7a900142e - std::sys::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\sys\backtrace.rs:152
  14:     0x7ff7a9001401 - std::rt::lang_start::closure$0<tuple$<> >
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\rt.rs:162
  15:     0x7ff7a9004279 - std::rt::lang_start_internal::closure$2
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\rt.rs:141
  16:     0x7ff7a9004279 - std::panicking::try::do_call
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panicking.rs:557
  17:     0x7ff7a9004279 - std::panicking::try
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panicking.rs:521
  18:     0x7ff7a9004279 - std::panic::catch_unwind
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panic.rs:350
  19:     0x7ff7a9004279 - std::rt::lang_start_internal
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\rt.rs:141
  20:     0x7ff7a90013da - std::rt::lang_start<tuple$<> >
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\rt.rs:161
  21:     0x7ff7a9001309 - main
  22:     0x7ff7a903b918 - invoke_main
                               at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  23:     0x7ff7a903b918 - __scrt_common_main_seh
                               at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  24:     0x7ffaad70257d - BaseThreadInitThunk
  25:     0x7ffaae1eaf28 - RtlUserThreadStart
```
</details>

The second issue is that Rust and Tracy initialize the symbol helper in different ways.
Since Rust 1.78.0 the compiler no longer includes absolute paths to .pdb files in the binary (https://github.com/rust-lang/rust/pull/121297). That can make the symbol resolution fail because by default only the current working directory is searched for .pdb files.
There was also a corresponding PR to `backtrace-rs` to include the executable location in the search path (https://github.com/rust-lang/backtrace-rs/pull/584), but when Tracy initializes `dbghelp.dll` first, the modules get loaded before the search path gets modified.
The second commit in this PR fixes that by capturing and resolving a backtrace using the standard library before Tracy does the initialization.
This fixes #101.