### PR TITLE
Latest release on crates.io causes compilation errors

### DIFF
--- a/make_sys.sh
+++ b/make_sys.sh
@@ -36,6 +36,7 @@ COMMON_BINDGEN_PARAMS=(
 bindgen -o "tracy-client-sys/src/generated.rs" \
   --allowlist-function='.*[Tt][Rr][Aa][Cc][Yy].*' \
   --allowlist-type='.*[Tt][Rr][Aa][Cc][Yy].*' \
+  --blocklist-type='TracyCLockCtx' \
   ${COMMON_BINDGEN_PARAMS[@]}
 
 bindgen -o "tracy-client-sys/src/generated_manual_lifetime.rs" \

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -56,3 +56,7 @@ debuginfod = ["client/debuginfod"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]
 all-features = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn" 
+check-cfg = ['cfg(tracing_tracy_docs)']

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -54,3 +54,7 @@ debuginfod = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "tracy_client_sys_docs"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(tracy_client_sys_docs)']

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -95,7 +95,7 @@ fn build_tracy_client() {
 
         let _ = builder
             .file("tracy/TracyClient.cpp")
-            .warnings(false)
+            .cargo_warnings(false)
             .cpp(true);
         if let Ok(tool) = builder.try_get_compiler() {
             if tool.is_like_gnu() || tool.is_like_clang() {

--- a/tracy-client-sys/src/generated.rs
+++ b/tracy-client-sys/src/generated.rs
@@ -3,7 +3,7 @@ pub const TracyPlotFormatEnum_TracyPlotFormatMemory: TracyPlotFormatEnum = 1;
 pub const TracyPlotFormatEnum_TracyPlotFormatPercentage: TracyPlotFormatEnum = 2;
 pub const TracyPlotFormatEnum_TracyPlotFormatWatt: TracyPlotFormatEnum = 3;
 type TracyPlotFormatEnum = ::std::os::raw::c_uint;
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_set_thread_name(name: *const ::std::os::raw::c_char);
 }
 #[repr(C)]
@@ -15,114 +15,39 @@ pub struct ___tracy_source_location_data {
     pub line: u32,
     pub color: u32,
 }
-#[test]
-fn bindgen_test_layout____tracy_source_location_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_source_location_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_source_location_data>(),
-        32usize,
-        concat!("Size of: ", stringify!(___tracy_source_location_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_source_location_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_source_location_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(name)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).function) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(function)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).file) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(file)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).line) as usize - ptr as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(line)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).color) as usize - ptr as usize },
-        28usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(color)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_source_location_data"]
+        [::std::mem::size_of::<___tracy_source_location_data>() - 32usize];
+    ["Alignment of ___tracy_source_location_data"]
+        [::std::mem::align_of::<___tracy_source_location_data>() - 8usize];
+    ["Offset of field: ___tracy_source_location_data::name"]
+        [::std::mem::offset_of!(___tracy_source_location_data, name) - 0usize];
+    ["Offset of field: ___tracy_source_location_data::function"]
+        [::std::mem::offset_of!(___tracy_source_location_data, function) - 8usize];
+    ["Offset of field: ___tracy_source_location_data::file"]
+        [::std::mem::offset_of!(___tracy_source_location_data, file) - 16usize];
+    ["Offset of field: ___tracy_source_location_data::line"]
+        [::std::mem::offset_of!(___tracy_source_location_data, line) - 24usize];
+    ["Offset of field: ___tracy_source_location_data::color"]
+        [::std::mem::offset_of!(___tracy_source_location_data, color) - 28usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_c_zone_context {
     pub id: u32,
     pub active: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout____tracy_c_zone_context() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_c_zone_context> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_c_zone_context>(),
-        8usize,
-        concat!("Size of: ", stringify!(___tracy_c_zone_context))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_c_zone_context>(),
-        4usize,
-        concat!("Alignment of ", stringify!(___tracy_c_zone_context))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_c_zone_context),
-            "::",
-            stringify!(id)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).active) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_c_zone_context),
-            "::",
-            stringify!(active)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_c_zone_context"][::std::mem::size_of::<___tracy_c_zone_context>() - 8usize];
+    ["Alignment of ___tracy_c_zone_context"]
+        [::std::mem::align_of::<___tracy_c_zone_context>() - 4usize];
+    ["Offset of field: ___tracy_c_zone_context::id"]
+        [::std::mem::offset_of!(___tracy_c_zone_context, id) - 0usize];
+    ["Offset of field: ___tracy_c_zone_context::active"]
+        [::std::mem::offset_of!(___tracy_c_zone_context, active) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_time_data {
@@ -130,52 +55,18 @@ pub struct ___tracy_gpu_time_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_time_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_time_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_time_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_time_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_time_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_time_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_time_data"][::std::mem::size_of::<___tracy_gpu_time_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_time_data"]
+        [::std::mem::align_of::<___tracy_gpu_time_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_time_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_time_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, queryId) - 8usize];
+    ["Offset of field: ___tracy_gpu_time_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, context) - 10usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_begin_data {
@@ -183,52 +74,19 @@ pub struct ___tracy_gpu_zone_begin_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_begin_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_begin_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_begin_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_zone_begin_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_begin_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_zone_begin_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).srcloc) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(srcloc)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_begin_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_begin_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_zone_begin_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_begin_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::srcloc"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, srcloc) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, queryId) - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, context) - 10usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_begin_callstack_data {
@@ -237,110 +95,38 @@ pub struct ___tracy_gpu_zone_begin_callstack_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_begin_callstack_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_begin_callstack_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_begin_callstack_data>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_begin_callstack_data>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).srcloc) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(srcloc)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).depth) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(depth)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_begin_callstack_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_begin_callstack_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_zone_begin_callstack_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_begin_callstack_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::srcloc"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, srcloc) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::depth"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, depth) - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, queryId) - 12usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, context) - 14usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_end_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_end_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_end_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_end_data>(),
-        4usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_zone_end_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_end_data>(),
-        2usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_zone_end_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_end_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_end_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_end_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_end_data>() - 4usize];
+    ["Alignment of ___tracy_gpu_zone_end_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_end_data>() - 2usize];
+    ["Offset of field: ___tracy_gpu_zone_end_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_end_data, queryId) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_end_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_end_data, context) - 2usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_new_context_data {
@@ -350,72 +136,23 @@ pub struct ___tracy_gpu_new_context_data {
     pub flags: u8,
     pub type_: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_new_context_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_new_context_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_new_context_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_new_context_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_new_context_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_new_context_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).period) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(period)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(context)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).flags) as usize - ptr as usize },
-        13usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(flags)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(type_)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_new_context_data"]
+        [::std::mem::size_of::<___tracy_gpu_new_context_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_new_context_data"]
+        [::std::mem::align_of::<___tracy_gpu_new_context_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::period"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, period) - 8usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, context) - 12usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::flags"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, flags) - 13usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::type_"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, type_) - 14usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_context_name_data {
@@ -423,52 +160,19 @@ pub struct ___tracy_gpu_context_name_data {
     pub name: *const ::std::os::raw::c_char,
     pub len: u16,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_context_name_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_context_name_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_context_name_data>(),
-        24usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_context_name_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_context_name_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_context_name_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(context)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(name)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(len)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_context_name_data"]
+        [::std::mem::size_of::<___tracy_gpu_context_name_data>() - 24usize];
+    ["Alignment of ___tracy_gpu_context_name_data"]
+        [::std::mem::align_of::<___tracy_gpu_context_name_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, context) - 0usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::name"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, name) - 8usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::len"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, len) - 16usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_calibration_data {
@@ -476,102 +180,43 @@ pub struct ___tracy_gpu_calibration_data {
     pub cpuDelta: i64,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_calibration_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_calibration_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_calibration_data>(),
-        24usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_calibration_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_calibration_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_calibration_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cpuDelta) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(cpuDelta)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_calibration_data"]
+        [::std::mem::size_of::<___tracy_gpu_calibration_data>() - 24usize];
+    ["Alignment of ___tracy_gpu_calibration_data"]
+        [::std::mem::align_of::<___tracy_gpu_calibration_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::cpuDelta"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, cpuDelta) - 8usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, context) - 16usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_time_sync_data {
     pub gpuTime: i64,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_time_sync_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_time_sync_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_time_sync_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_time_sync_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_time_sync_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_time_sync_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_sync_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_sync_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_time_sync_data"]
+        [::std::mem::size_of::<___tracy_gpu_time_sync_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_time_sync_data"]
+        [::std::mem::align_of::<___tracy_gpu_time_sync_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_time_sync_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_time_sync_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_time_sync_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_time_sync_data, context) - 8usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __tracy_lockable_context_data {
     _unused: [u8; 0],
 }
 type TracyCZoneCtx = ___tracy_c_zone_context;
-type TracyCLockCtx = *mut __tracy_lockable_context_data;
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_alloc_srcloc(
         line: u32,
         source: *const ::std::os::raw::c_char,
@@ -581,7 +226,7 @@ extern "C" {
         color: u32,
     ) -> u64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_alloc_srcloc_name(
         line: u32,
         source: *const ::std::os::raw::c_char,
@@ -593,132 +238,132 @@ extern "C" {
         color: u32,
     ) -> u64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_begin(
         srcloc: *const ___tracy_source_location_data,
         active: ::std::os::raw::c_int,
     ) -> TracyCZoneCtx;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_begin_callstack(
         srcloc: *const ___tracy_source_location_data,
         depth: ::std::os::raw::c_int,
         active: ::std::os::raw::c_int,
     ) -> TracyCZoneCtx;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_begin_alloc(
         srcloc: u64,
         active: ::std::os::raw::c_int,
     ) -> TracyCZoneCtx;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_begin_alloc_callstack(
         srcloc: u64,
         depth: ::std::os::raw::c_int,
         active: ::std::os::raw::c_int,
     ) -> TracyCZoneCtx;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_end(ctx: TracyCZoneCtx);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_text(
         ctx: TracyCZoneCtx,
         txt: *const ::std::os::raw::c_char,
         size: usize,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_name(
         ctx: TracyCZoneCtx,
         txt: *const ::std::os::raw::c_char,
         size: usize,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_color(ctx: TracyCZoneCtx, color: u32);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_zone_value(ctx: TracyCZoneCtx, value: u64);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin(arg1: ___tracy_gpu_zone_begin_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_callstack(arg1: ___tracy_gpu_zone_begin_callstack_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_alloc(arg1: ___tracy_gpu_zone_begin_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_alloc_callstack(
         arg1: ___tracy_gpu_zone_begin_callstack_data,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_end(data: ___tracy_gpu_zone_end_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_time(arg1: ___tracy_gpu_time_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_new_context(arg1: ___tracy_gpu_new_context_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_context_name(arg1: ___tracy_gpu_context_name_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_calibration(arg1: ___tracy_gpu_calibration_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_time_sync(arg1: ___tracy_gpu_time_sync_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_serial(arg1: ___tracy_gpu_zone_begin_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_callstack_serial(
         arg1: ___tracy_gpu_zone_begin_callstack_data,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_alloc_serial(arg1: ___tracy_gpu_zone_begin_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_begin_alloc_callstack_serial(
         arg1: ___tracy_gpu_zone_begin_callstack_data,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_zone_end_serial(data: ___tracy_gpu_zone_end_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_time_serial(arg1: ___tracy_gpu_time_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_new_context_serial(arg1: ___tracy_gpu_new_context_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_context_name_serial(arg1: ___tracy_gpu_context_name_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_calibration_serial(arg1: ___tracy_gpu_calibration_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_gpu_time_sync_serial(arg1: ___tracy_gpu_time_sync_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_connected() -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_alloc(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
         secure: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_alloc_callstack(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
@@ -726,20 +371,20 @@ extern "C" {
         secure: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_free(
         ptr: *const ::std::os::raw::c_void,
         secure: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_free_callstack(
         ptr: *const ::std::os::raw::c_void,
         depth: ::std::os::raw::c_int,
         secure: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_alloc_named(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
@@ -747,7 +392,7 @@ extern "C" {
         name: *const ::std::os::raw::c_char,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_alloc_callstack_named(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
@@ -756,14 +401,14 @@ extern "C" {
         name: *const ::std::os::raw::c_char,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_free_named(
         ptr: *const ::std::os::raw::c_void,
         secure: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_memory_free_callstack_named(
         ptr: *const ::std::os::raw::c_void,
         depth: ::std::os::raw::c_int,
@@ -771,20 +416,20 @@ extern "C" {
         name: *const ::std::os::raw::c_char,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_message(
         txt: *const ::std::os::raw::c_char,
         size: usize,
         callstack: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_messageL(
         txt: *const ::std::os::raw::c_char,
         callstack: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_messageC(
         txt: *const ::std::os::raw::c_char,
         size: usize,
@@ -792,23 +437,23 @@ extern "C" {
         callstack: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_messageLC(
         txt: *const ::std::os::raw::c_char,
         color: u32,
         callstack: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_frame_mark(name: *const ::std::os::raw::c_char);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_frame_mark_start(name: *const ::std::os::raw::c_char);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_frame_mark_end(name: *const ::std::os::raw::c_char);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_frame_image(
         image: *const ::std::os::raw::c_void,
         w: u16,
@@ -817,16 +462,16 @@ extern "C" {
         flip: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_plot(name: *const ::std::os::raw::c_char, val: f64);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_plot_float(name: *const ::std::os::raw::c_char, val: f32);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_plot_int(name: *const ::std::os::raw::c_char, val: i64);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_plot_config(
         name: *const ::std::os::raw::c_char,
         type_: ::std::os::raw::c_int,
@@ -835,41 +480,41 @@ extern "C" {
         color: u32,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_emit_message_appinfo(txt: *const ::std::os::raw::c_char, size: usize);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_announce_lockable_ctx(
         srcloc: *const ___tracy_source_location_data,
     ) -> *mut __tracy_lockable_context_data;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_terminate_lockable_ctx(lockdata: *mut __tracy_lockable_context_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_before_lock_lockable_ctx(
         lockdata: *mut __tracy_lockable_context_data,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_after_lock_lockable_ctx(lockdata: *mut __tracy_lockable_context_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_after_unlock_lockable_ctx(lockdata: *mut __tracy_lockable_context_data);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_after_try_lock_lockable_ctx(
         lockdata: *mut __tracy_lockable_context_data,
         acquired: ::std::os::raw::c_int,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_mark_lockable_ctx(
         lockdata: *mut __tracy_lockable_context_data,
         srcloc: *const ___tracy_source_location_data,
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_custom_name_lockable_ctx(
         lockdata: *mut __tracy_lockable_context_data,
         name: *const ::std::os::raw::c_char,

--- a/tracy-client-sys/src/generated_fibers.rs
+++ b/tracy-client-sys/src/generated_fibers.rs
@@ -1,6 +1,6 @@
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_fiber_enter(fiber: *const ::std::os::raw::c_char);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_fiber_leave();
 }

--- a/tracy-client-sys/src/generated_manual_lifetime.rs
+++ b/tracy-client-sys/src/generated_manual_lifetime.rs
@@ -1,6 +1,6 @@
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_startup_profiler();
 }
-extern "C" {
+unsafe extern "C" {
     pub fn ___tracy_shutdown_profiler();
 }

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -70,3 +70,7 @@ debuginfod = ["sys/debuginfod"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]
 all-features = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(tracy_client_docs)', 'cfg(loom)']

--- a/tracy-client/src/plot.rs
+++ b/tracy-client/src/plot.rs
@@ -169,25 +169,27 @@ impl Client {
     ///     .plot_config(tracy_client::plot_name!("memory"), PlotConfiguration::default().format(PlotFormat::Memory));
     /// ```
     pub fn plot_config(&self, plot_name: PlotName, configuration: PlotConfiguration) {
-        let format = match configuration.format {
-            PlotFormat::Number => sys::TracyPlotFormatEnum_TracyPlotFormatNumber,
-            PlotFormat::Memory => sys::TracyPlotFormatEnum_TracyPlotFormatMemory,
-            PlotFormat::Percentage => sys::TracyPlotFormatEnum_TracyPlotFormatPercentage,
-            PlotFormat::Watts => sys::TracyPlotFormatEnum_TracyPlotFormatWatt,
-        } as std::os::raw::c_int;
-        let stepped = configuration.line_style == PlotLineStyle::Stepped;
-        let filled = configuration.fill;
-        let color = configuration.color.unwrap_or(0);
         #[cfg(feature = "enable")]
-        unsafe {
-            // SAFE: We made sure the `plot` refers to a null-terminated string.
-            let () = sys::___tracy_emit_plot_config(
-                plot_name.0.as_ptr().cast(),
-                format,
-                stepped.into(),
-                filled.into(),
-                color,
-            );
+        {
+            let format = match configuration.format {
+                PlotFormat::Number => sys::TracyPlotFormatEnum_TracyPlotFormatNumber,
+                PlotFormat::Memory => sys::TracyPlotFormatEnum_TracyPlotFormatMemory,
+                PlotFormat::Percentage => sys::TracyPlotFormatEnum_TracyPlotFormatPercentage,
+                PlotFormat::Watts => sys::TracyPlotFormatEnum_TracyPlotFormatWatt,
+            } as std::os::raw::c_int;
+            let stepped = configuration.line_style == PlotLineStyle::Stepped;
+            let filled = configuration.fill;
+            let color = configuration.color.unwrap_or(0);
+            unsafe {
+                // SAFE: We made sure the `plot` refers to a null-terminated string.
+                let () = sys::___tracy_emit_plot_config(
+                    plot_name.0.as_ptr().cast(),
+                    format,
+                    stepped.into(),
+                    filled.into(),
+                    color,
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Tracy-client version 0.17.5 on crates.io does not compile, if the 'enabled' feature is turned of:

```
error[E0425]: cannot find value `TracyPlotFormatEnum_TracyPlotFormatNumber` in crate `sys`
   --> /home/XXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracy-client-0.17.5/src/plot.rs:173:40
    |
173 |             PlotFormat::Number => sys::TracyPlotFormatEnum_TracyPlotFormatNumber,
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `sys`
```

This was, because the code referred to `sys::TracyPlotFormatEnum_TracyPlotFormatNumber` outside of a `#[cfg(feature = "enable")]` scope. But if the 'enabled' feature is turned off, then this constant does not exist. The fix for this was quite trivial and is in the first commit of this PR. I'd recommend making a new release and maybe even yanking the current version 0.17.5 from crates.io.

Since I was already at it, I also cleaned up a few compiler warnings. They are contained in the remaining 4 commits of this PR. See the commit messages for details. I made sure to carefully split everything into individual commits so that you can cherry-pick the changes that you want, in case you don't want all of them.

Thanks for all your work for this awesome rust library!