### PR TITLE
Expose `TRACY_NO_CRASH_HANDLER` define as default `crash-handler` feature flag

### DIFF
--- a/FEATURES.mkd
+++ b/FEATURES.mkd
@@ -39,6 +39,8 @@
   corresponds to the `TRACY_NO_VERIFY` define.
 * `debuginfod` - enables debuginfo for system libraries on systems supporting debuginfod.
   Corresponds to the `TRACY_DEBUGINFOD` define.
+* `crash-handler` – activate signal handler that intercepts application crashes. Corresponds to the
+  `TRACY_NO_CRASH_HANDLER` define.
 
 Refer to this package's `Cargo.toml` for the list of the features enabled by default. Refer to
 the `Tracy` manual for more information on the implications of each feature.

--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -33,7 +33,7 @@ criterion = "0.5"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
+            "broadcast", "callstack-inlines", "crash-handler" ]
 broadcast = ["client/broadcast"]
 code-transfer = ["client/code-transfer"]
 context-switch-tracing = ["client/context-switch-tracing"]
@@ -52,6 +52,7 @@ flush-on-exit = ["client/flush-on-exit"]
 demangle = ["client/demangle"]
 verify = ["client/verify"]
 debuginfod = ["client/debuginfod"]
+crash-handler = ["client/crash-handler"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_tracy_docs"]

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -31,7 +31,7 @@ cc = { version = "1.0.83", default-features = false }
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
+            "broadcast", "callstack-inlines", "crash-handler" ]
 enable = []
 fibers = []
 system-tracing = []
@@ -50,6 +50,7 @@ flush-on-exit = []
 demangle = []
 verify = []
 debuginfod = []
+crash-handler = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -80,6 +80,9 @@ fn set_feature_defines(mut c: cc::Build) -> cc::Build {
     if std::env::var_os("CARGO_FEATURE_VERIFY").is_none() {
         c.define("TRACY_NO_VERIFY", None);
     }
+    if std::env::var_os("CARGO_FEATURE_CRASH_HANDLER").is_none() {
+        c.define("TRACY_NO_CRASH_HANDLER", None);
+    }
     c
 }
 

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.7"
 [features]
 # Refer to FEATURES.mkd for documentation on features.
 default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines" ]
+            "broadcast", "callstack-inlines", "crash-handler" ]
 broadcast = ["sys/broadcast"]
 code-transfer = ["sys/code-transfer"]
 context-switch-tracing = ["sys/context-switch-tracing"]
@@ -66,6 +66,7 @@ flush-on-exit = ["sys/flush-on-exit"]
 demangle = ["sys/demangle", "dep:rustc-demangle"]
 verify = ["sys/verify"]
 debuginfod = ["sys/debuginfod"]
+crash-handler = ["sys/crash-handler"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracy_client_docs"]


### PR DESCRIPTION
While this is surely a _very_ niche feature, turning off the default crash handler can be useful in situations where the tracee sets up and uses signal handlers in normal operation.