### PR TITLE
CUDA PoC

### DIFF
--- a/tracing-tracy/Cargo.toml
+++ b/tracing-tracy/Cargo.toml
@@ -19,21 +19,33 @@ bench = true
 
 [dependencies]
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "registry"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "fmt",
+    "registry",
+] }
 client = { package = "tracy-client", path = "../tracy-client", version = ">=0.17.0,<0.19.0", default-features = false }
+sys = { package = "tracy-client-sys", path = "../tracy-client-sys" }
 
 [dev-dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tokio = { version = "1", features = ["full"] }
-tracing-attributes =  { version = "0.1"}
+tracing-attributes = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 futures = "0.3"
 criterion = "0.5"
 
 [features]
 # Refer to FEATURES.mkd for documentation on features.
-default = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer",
-            "broadcast", "callstack-inlines", "crash-handler" ]
+default = [
+    "enable",
+    "system-tracing",
+    "context-switch-tracing",
+    "sampling",
+    "code-transfer",
+    "broadcast",
+    "callstack-inlines",
+    "crash-handler",
+]
 broadcast = ["client/broadcast"]
 code-transfer = ["client/code-transfer"]
 context-switch-tracing = ["client/context-switch-tracing"]

--- a/tracing-tracy/src/lib.rs
+++ b/tracing-tracy/src/lib.rs
@@ -96,10 +96,12 @@ impl<C> TracyLayer<C> {
     /// Defaults to collecting stack traces.
     #[must_use]
     pub fn new(config: C) -> Self {
-        Self {
-            config,
-            client: Client::start(),
-        }
+        let client = Client::start();
+
+        // Just to see how CUDA profiling works
+        unsafe { sys::tracy_CUDACtx_StartProfiling(sys::tracy_CUDACtx_Create()) };
+
+        Self { config, client }
     }
 }
 

--- a/tracy-client-sys/build.rs
+++ b/tracy-client-sys/build.rs
@@ -98,7 +98,8 @@ fn build_tracy_client() {
 
         let _ = builder
             .file("tracy/TracyClient.cpp")
-            .cargo_warnings(false)
+            .define("TRACY_ENABLE", "1")
+            .include("tracy/TracyCUDA.hpp")
             .cpp(true);
         if let Ok(tool) = builder.try_get_compiler() {
             if tool.is_like_gnu() || tool.is_like_clang() {

--- a/tracy-client-sys/src/generated_cuda.rs
+++ b/tracy-client-sys/src/generated_cuda.rs
@@ -1,0 +1,131 @@
+/*
+The real generated file was made like so:
+
+bindgen -o "tracy-client-sys/src/generated_cuda.rs" --rust-target "1.70.0" --allowlist-function='.*tracy::CUDACtx.*' --blocklist-type='TracyCLockCtx' "tracy-client-sys/tracy/tracy/TracyCUDA.hpp" --no-size_t-is-usize --generate-inline-functions -- -xc++ -DTRACY_ENABLE -I/opt/cuda/targets/x86_64-linux/include -I/opt/cuda/extras/CUPTI/include -Itracy-client-sys/tracy --target=x86_64-unknown-linux-gnu
+
+it contains _way_ too much stuff, including stuff that doesn't compile due to strange type definitions
+including hash maps and generics.
+
+For just testing the simplest thing to do was to just perform surgery to keep only the necessary parts.
+Which essentially is
+    - pub fn tracy_CUDACtx_Create() -> *mut tracy_CUDACtx;
+    - pub fn tracy_CUDACtx_StartProfiling(ctx: *mut tracy_CUDACtx);
+
+The other code relating to threads and mutexes etc. is just there to make
+the program compile since tracy_CUDACtx needs them.
+*/
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+pub type __gthread_mutex_t = pthread_mutex_t;
+pub type std___mutex_base___native_type = __gthread_mutex_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct std___mutex_base {
+    pub _M_mutex: std___mutex_base___native_type,
+}
+extern "C" {
+    #[link_name = "\u{1}_ZNSt12__mutex_baseC1Ev"]
+    pub fn std___mutex_base___mutex_base(this: *mut std___mutex_base);
+}
+impl std___mutex_base {
+    #[inline]
+    pub unsafe fn new() -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        std___mutex_base___mutex_base(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
+    }
+}
+#[repr(C)]
+pub struct std_mutex {
+    pub _base: std___mutex_base,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct std_atomic<_Tp> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<_Tp>>,
+    pub _M_i: _Tp,
+}
+#[repr(C)]
+#[repr(align(64))]
+#[derive(Debug)]
+pub struct tracy_CUDACtx {
+    pub m_tracyGpuContext: u8,
+    pub __bindgen_padding_0: [u16; 31usize],
+    pub m_queryIdGen: std_atomic<u16>,
+}
+#[repr(C)]
+pub struct tracy_CUDACtx_Singleton {
+    pub ctx: *mut tracy_CUDACtx,
+    pub m: std_mutex,
+    pub ref_count: ::std::os::raw::c_int,
+    pub ctx_id: u8,
+}
+
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx9Singleton3GetEv"]
+    pub fn tracy_CUDACtx_Singleton_Get() -> *mut tracy_CUDACtx_Singleton;
+}
+impl tracy_CUDACtx_Singleton {
+    #[inline]
+    pub unsafe fn Get() -> *mut tracy_CUDACtx_Singleton {
+        tracy_CUDACtx_Singleton_Get()
+    }
+}
+
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx6CreateEv"]
+    pub fn tracy_CUDACtx_Create() -> *mut tracy_CUDACtx;
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx7DestroyEPS0_"]
+    pub fn tracy_CUDACtx_Destroy(ctx: *mut tracy_CUDACtx);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx7CollectEv"]
+    pub fn tracy_CUDACtx_Collect(this: *mut tracy_CUDACtx);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx10printStatsEv"]
+    pub fn tracy_CUDACtx_printStats(this: *mut tracy_CUDACtx);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx14StartProfilingEv"]
+    pub fn tracy_CUDACtx_StartProfiling(this: *mut tracy_CUDACtx);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx13StopProfilingEv"]
+    pub fn tracy_CUDACtx_StopProfiling(this: *mut tracy_CUDACtx);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN5tracy7CUDACtx4NameEPKct"]
+    pub fn tracy_CUDACtx_Name(
+        this: *mut tracy_CUDACtx,
+        name: *const ::std::os::raw::c_char,
+        len: u16,
+    );
+}

--- a/tracy-client-sys/src/lib.rs
+++ b/tracy-client-sys/src/lib.rs
@@ -41,6 +41,11 @@ mod generated;
 #[cfg(feature = "enable")]
 pub use generated::*;
 
+#[cfg(feature = "enable")]
+mod generated_cuda;
+#[cfg(feature = "enable")]
+pub use generated_cuda::*;
+
 #[cfg(all(feature = "enable", feature = "manual-lifetime"))]
 mod generated_manual_lifetime;
 #[cfg(all(feature = "enable", feature = "manual-lifetime"))]


### PR DESCRIPTION
In similar spirit to #144 , putting this up as a draft in case someone is interested.

Just does the minimal dirty work necessary to see how CUDA work could be added to Tracy.

Here is an example of a complex app that uses async + this PR:

<img width="1688" height="1049" alt="image" src="https://github.com/user-attachments/assets/d14e5511-dfc6-40c0-a32b-c6381e39c9cc" />

Before this the CPU work (bottom left, top right) would just look like it had empty air in-between, but now we see there are mem copies going on.

Another example:

<img width="2030" height="554" alt="image" src="https://github.com/user-attachments/assets/6283a432-7098-439c-97ac-ada581fa105d" />


The above shows CPU work sections connected by lots of kernel launches.


The GPU related activity is quite noisy.


The PR lacks a few things:

- A proper bindgen command with an `allowlist` that is close to the hand-picked "generated_cuda" file in this PR. See that file for the command used in this PR. Using that command produces thousands of lines of Rust code with bindings to things which aren't useful and won't even compile.
- A layer on top of the sys crate that allows opt-in to CUDA. This way `tracing-tracy` won't need a dep on the sys crate. Opt-in perhaps through options on `TracyLayer` or something.
- A CUDA feature flag
- Cleanup? Calling `tracy_CUDACtx_Destroy` at some point. Not sure it's actually worthwhile.
- Seeing if `tracy_CUDACtx_Name` does something nice
- Figuring out why there are so many unknown spans with little info