### PR TITLE
Allow (static) custom source locations for spans

### DIFF
--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -74,12 +74,12 @@ pub mod internal {
             SpanLocation {
                 data: sys::___tracy_source_location_data {
                     name: span_name.cast(),
-                    function: function_name.as_ptr(),
+                    // Leak the string; `make_span_location` is only used inside `static`s.
+                    function: function_name.into_raw().cast(),
                     file: file.cast(),
                     line,
                     color: 0,
                 },
-                _function_name: function_name,
             }
         }
         #[cfg(not(feature = "enable"))]

--- a/tracy-client/src/lib.rs
+++ b/tracy-client/src/lib.rs
@@ -67,6 +67,7 @@ pub mod internal {
         span_name: *const u8,
         file: *const u8,
         line: u32,
+        color: u32,
     ) -> SpanLocation {
         #[cfg(feature = "enable")]
         {
@@ -78,7 +79,32 @@ pub mod internal {
                     function: function_name.into_raw().cast(),
                     file: file.cast(),
                     line,
-                    color: 0,
+                    color,
+                },
+            }
+        }
+        #[cfg(not(feature = "enable"))]
+        crate::SpanLocation { _internal: () }
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub const fn static_span_location(
+        function: *const u8,
+        name: *const u8,
+        file: *const u8,
+        line: u32,
+        color: u32,
+    ) -> SpanLocation {
+        #[cfg(feature = "enable")]
+        {
+            SpanLocation {
+                data: sys::___tracy_source_location_data {
+                    name: name.cast(),
+                    function: function.cast(),
+                    file: file.cast(),
+                    line,
+                    color,
                 },
             }
         }

--- a/tracy-client/src/span.rs
+++ b/tracy-client/src/span.rs
@@ -1,5 +1,4 @@
 use crate::{adjust_stack_depth, Client};
-use std::ffi::CString;
 
 /// A handle representing a span of execution.
 ///
@@ -19,8 +18,6 @@ pub struct Span {
 ///
 /// Construct with the [`span_location!`](crate::span_location) macro.
 pub struct SpanLocation {
-    #[cfg(feature = "enable")]
-    pub(crate) _function_name: CString,
     #[cfg(feature = "enable")]
     pub(crate) data: sys::___tracy_source_location_data,
     #[cfg(not(feature = "enable"))]

--- a/tracy-client/src/span.rs
+++ b/tracy-client/src/span.rs
@@ -191,45 +191,86 @@ impl Drop for Span {
 ///
 /// The returned `SpanLocation` is allocated statically and is cached between invocations. This
 /// `SpanLocation` will refer to the file and line at which this macro has been invoked, as well as
-/// to the item containing this macro invocation.
+/// to the item containing this macro invocation, unless overridden.
 ///
 /// The resulting value may be used as an argument for the [`Client::span`] method.
 ///
 /// # Example
 ///
 /// ```rust
-/// let location: &'static tracy_client::SpanLocation = tracy_client::span_location!("some name");
+/// use tracy_client::{SpanLocation, span_location};
+///
+/// let location: &'static SpanLocation = span_location!("some name");
+/// // A long-form syntax is also available to specify custom source
+/// // locations; all fields are optional.
+/// let location: &'static SpanLocation = span_location! {
+///     name: "another name",
+///     function: "my::fake::function",
+///     file: "path/to/fake/file.rs",
+///     line: 42,
+///     color: 0x99CC66, // in RGB format
+/// };
 /// ```
 #[macro_export]
 macro_rules! span_location {
-    () => {{
+    ($name: expr) => {
+        $crate::__span_location_helper!([name $name])
+    };
+    ($($field: ident: $value: expr),* $(,)?) => {
+        $crate::__span_location_helper!($([$field $value])*)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __span_location_helper {
+    (
+        $([name $name: expr])?
+        [function $function: expr]
+        $([file $file: expr])?
+        $([line $line: expr])?
+        $([color $color: expr])?
+    ) => {{
+        static LOC: $crate::internal::SpanLocation =
+            $crate::internal::static_span_location(
+                concat!($function, "\0").as_ptr(),
+                $crate::__span_location_helper!(@name $($name)?),
+                $crate::__span_location_helper!(@file $($file)?),
+                $crate::__span_location_helper!(@line $($line)?),
+                $crate::__span_location_helper!(@color $($color)?),
+            );
+        &LOC
+    }};
+
+    (
+        $([name $name: expr])?
+        $([file $file: expr])?
+        $([line $line: expr])?
+        $([color $color: expr])?
+    ) => {{
         struct S;
         // String processing in `const` when, Oli?
         static LOC: $crate::internal::Lazy<$crate::internal::SpanLocation> =
             $crate::internal::Lazy::new(|| {
                 $crate::internal::make_span_location(
                     $crate::internal::type_name::<S>(),
-                    $crate::internal::null(),
-                    concat!(file!(), "\0").as_ptr(),
-                    line!(),
+                    $crate::__span_location_helper!(@name $($name)?),
+                    $crate::__span_location_helper!(@file $($file)?),
+                    $crate::__span_location_helper!(@line $($line)?),
+                    $crate::__span_location_helper!(@color $($color)?),
                 )
             });
         &*LOC
     }};
-    ($name: expr) => {{
-        struct S;
-        // String processing in `const` when, Oli?
-        static LOC: $crate::internal::Lazy<$crate::internal::SpanLocation> =
-            $crate::internal::Lazy::new(|| {
-                $crate::internal::make_span_location(
-                    $crate::internal::type_name::<S>(),
-                    concat!($name, "\0").as_ptr(),
-                    concat!(file!(), "\0").as_ptr(),
-                    line!(),
-                )
-            });
-        &*LOC
-    }};
+
+    (@name $name: expr) => { concat!($name, "\0").as_ptr() };
+    (@name) => { $crate::internal::null() };
+    (@file $file: expr) => { concat!($file, "\0").as_ptr() };
+    (@file) => { concat!(file!(), "\0").as_ptr() };
+    (@line $line: expr) => { $line };
+    (@line) => { line!() };
+    (@color $color: expr) => { $color };
+    (@color) => { 0 };
 }
 
 /// Start a new Tracy span with function, file, and line determined automatically.


### PR DESCRIPTION
Closes #108 by expanding `span_location!` to allow overriding source locations:
```rs
let location: &'static SpanLocation = span_location! {
    name: "another name",
    function: "my::fake::function",
    file: "path/to/fake/file.rs",
    line: 42,
    color: 0x99CC66, // in RGB format
};
```

As an optimization, when the `function` name is provided statically, the `Lazy` wrapper is skipped.

EDIT: Also closes #106 by adding color support to static spans

-----

I considered adding a `const SpanLocation::new` constructor, but this would mean adding a way of making static nul-terminated strings outside of `FrameName/PlotName::new_leak`, so I skipped this for now. What do you think about adding an unified `StaticName/static_name!` type/macro that could be used everywhere Tracy expects such strings?